### PR TITLE
Deferred session requests

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -753,11 +753,11 @@ xrSession.addEventListener('resetpose', xrSessionEvent => {
 
 WebXR applications can, like any web page, link to other pages. In the context of an exclusive `XRSession`, this is handled by setting `window.location` to the desired URL when the user performs some action. If the page being linked to is not XR-capable the user will either have to remove the XR device to view it or the page could be shown as a 2D page in a XR browser.
 
-If the page being navigated to is XR capable, however, it's frequently desirable to allow the developer to immediately create an exclusive `XRSession` for that page as well, so that the user feels as though they are navigating through a single continuous XR experience. To allow this the UA tracks when a page navigates without ending an active exclusive session first. This flags the newly loaded page as "XR navigable".
+If the page being navigated to is XR capable, however, it's frequently desirable to allow the developer to immediately create an exclusive `XRSession` for that page as well, so that the user feels as though they are navigating through a single continuous XR experience. This is triggered when a page initiates navigation without ending an active exclusive session first. When this happens, if the UA supports XR navigation and does not suppress the navigation for other reasons, the UA sets an internal "allow XR navigation" flag to true.
 
-In order to start presenting automatically when a page is XR navigable, pages can make a "deferred" session request. To request a deferred session the option `{ waitForNavigate: true }` is passed into the `requestSession` call. If the page is XR navigable, the request will be resolved when the page is ready to begin presenting. If the page is not XR navigable the request will reject immediately.
+In order for the next page to start presenting automatically when the UA allows XR navigation, pages can make a "deferred" session request. To create a deferred session request the option `{ waitForNavigate: true }` is passed into the `requestSession` call. If the UA's allow XR navigation flag is set, the request will be resolved when the page is ready to begin presenting. If the UA's allow XR navigation flag is not set, the request will reject immediately.
 
-Deferred sessions must be exclusive. If a non-exclusive deferred session is requested the promise will immediately be rejected. Deferred requests do not need to be made within a user gesture. Only one session request with the `waitForNavigate` option is allowed per page and subsequent requests using `waitForNavigate` will be rejected immediately. The page's XR navigable state must expire after all listeners for the `window`'s `load` event have fired.
+Deferred sessions requests must be exclusive. If a non-exclusive deferred session request is made, the promise will immediately be rejected. Deferred session requests do not need to be made within a user gesture. Only one session request with the `waitForNavigate` option is allowed per page and subsequent requests using `waitForNavigate` will be rejected immediately. The UA's allow XR navigation flag must revert to false after all listeners for the `window`'s `load` event have fired.
 
 ```js
 window.addEventListener('load', () => {
@@ -768,7 +768,7 @@ window.addEventListener('load', () => {
 ```
 
 > **Non-normative Notes:**
-> - Pages should not rely exclusively on deferred sessions as a method for presenting XR content, since it is not guaranteed that they will be supported in all environments. An in-page button for starting XR should always be provided as a best practice.
+> - Pages should not rely exclusively on deferred session requests as a method for presenting XR content, since it is not guaranteed that they will be supported in all environments. An in-page button for starting XR should always be provided as a best practice.
 > - UAs may place additional restrictions on what conditions are considered XR navigable, such as restricting it to only same-origin URLs.
 > - The UA should provide a visual transition between the two pages. Additionally, if the UA cannot display pages in XR it is recommended that it should instruct the user to remove the headset once the UA switches to displaying a 2D page.
 


### PR DESCRIPTION
This is an update to how we would handle device activation events, which I alluded to in #194. I've also combined it with some of the navigation concepts from #247, which appears to be another magical GitHub PR closure. (I'm doing something weird with my branches, I guess.)

The intent behind this style of session request is to make UA transition logic more predictable. By making a deferred request the UA knows that it can switch to presentation mode when the criteria is fulfilled, so there's no bouncing back and forth into Javascript and hoping that the page calls `requestSession` in response to an event firing. It's definitely something we've seen would be beneficial in Chrome.

I have some concerns out the gate that I'd like others opinions on: Not sure if the terminology (deferred session request, deferTill, etc) is right for the functionality. It especially feels a bit odd in the "navigate" case. Also it's awkward to me that `activate` is this new deferred thingy while `deactivate` is still a normal event. Finally, I kinda wonder whether or not we need `getNavigationDevice`. You could technically get by with just iterating through all of the devices and requesting a deferred navigate session against them. It would reject immediately on anything that wasn't valid for navigation. That feels a little ugly, but in reality most of the time you'd only have one device anyway. So maybe that's good enough for V1?

So I'd love feedback on any of that, or anything else that you've got thoughts on. Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/webvr/activate-promise.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/webvr/28aedb9...086405d.html)