### PR TITLE
 Policy change: reject `requestDevice` with `NotFoundError` if no devices found

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -63,7 +63,7 @@ The basic steps most WebXR applications will go through are:
 
 The first thing that any XR-enabled page will want to do is request an `XRDevice` and, if one is available, advertise VR functionality to the user. (For example, by adding a button to the page that the user can click to start XR content.)
 
-`navigator.xr.requestDevice` returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to an `XRDevice` if one is available. If no `XRDevice` is available, it will resolve to null. The promise will be rejected if an error occurs, such as the page not having the appropriate permissions to access VR capabilities.
+`navigator.xr.requestDevice` returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to an `XRDevice` if one is available. If no `XRDevice` is available, it will reject with a `NotFoundError`. The promise will also be rejected if an error occurs, such as the page not having the appropriate permissions to access VR capabilities.
 
 A `XRDevice` represents a physical unit of XR hardware that can present imagery to the user somehow, referred to here as an "XR hardware device". On desktop clients this will usually be a headset peripheral; on mobile clients it may represent the mobile device itself in conjunction with a viewer harness (e.g., Google Cardboard/Daydream or Samsung Gear VR). It may also represent devices without stereo-presentation capabilities but with more advanced tracking, such as ARCore/ARKit-compatible devices.
 

--- a/explainer.md
+++ b/explainer.md
@@ -63,7 +63,7 @@ The basic steps most WebXR applications will go through are:
 
 The first thing that any XR-enabled page will want to do is request an `XRDevice` and, if one is available, advertise VR functionality to the user. (For example, by adding a button to the page that the user can click to start XR content.)
 
-`navigator.xr.requestDevice` returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to an `XRDevice` if one is available. If no `XRDevice` is available, it will reject with a `NotFoundError`. The promise will also be rejected if an error occurs, such as the page not having the appropriate permissions to access VR capabilities.
+`navigator.xr.requestDevice` returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to an `XRDevice` if one is available. If no `XRDevice` is available, it will reject with a "NotFoundError". The promise will also be rejected with an appropriate error if an error occurs during the device query. For example, if the page does not have the appropriate permissions to access XR capabilities it would reject with a "NotAllowedError".
 
 A `XRDevice` represents a physical unit of XR hardware that can present imagery to the user somehow, referred to here as an "XR hardware device". On desktop clients this will usually be a headset peripheral; on mobile clients it may represent the mobile device itself in conjunction with a viewer harness (e.g., Google Cardboard/Daydream or Samsung Gear VR). It may also represent devices without stereo-presentation capabilities but with more advanced tracking, such as ARCore/ARKit-compatible devices.
 
@@ -72,7 +72,7 @@ function checkForXR() {
   navigator.xr.requestDevice().then(device => {
     onXRAvailable(device);
   }, err => {
-    if (err instanceof NotFoundError) {
+    if (err.name === 'NotFoundError') {
       // No XRDevices available.
       console.error('No XR devices available:', err);
     } else {

--- a/explainer.md
+++ b/explainer.md
@@ -70,12 +70,15 @@ A `XRDevice` represents a physical unit of XR hardware that can present imagery 
 ```js
 function checkForXR() {
   navigator.xr.requestDevice().then(device => {
-    if (device) {
-      onXRAvailable(device);
-    }
+    onXRAvailable(device);
   }, err => {
-    // An error occurred while requesting an XRDevice.
-    console.error('Unable to request an XR device:', err);
+    if (err instanceof NotFoundError) {
+      // No XRDevices available.
+      console.error('No XR devices available:', err);
+    } else {
+      // An error occurred while requesting an XRDevice.
+      console.error('Requesting XR device failed:', err);
+    }
   });
 }
 ```

--- a/spec/latest/index.bs
+++ b/spec/latest/index.bs
@@ -189,6 +189,7 @@ NOTE: The user agent is allowed to use any criteria it wishes to [=select a defa
 The page can <dfn>request a device</dfn> by calling the <dfn method for="XR">requestDevice()</dfn> method on the {{Navigator/xr}} object. When invoked it MUST return [=a new Promise=] |promise| and run the following steps [=in parallel=]:
 
   1. [=Enumerate XR devices=].
+  1. If the [=list of XR devices=] is empty, [=reject=] |promise| with a {{NotFoundError}} and abort these steps.
   1. [=Select a default XR device=] from the [=list of XR devices=].
   1. [=Resolve=] |promise| with the [=default device=].
 

--- a/spec/latest/index.html
+++ b/spec/latest/index.html
@@ -1440,7 +1440,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">WebXR Device API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-01-03">3 January 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-01-04">4 January 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1462,7 +1462,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 3 January 2018,
+In addition, as of 4 January 2018,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -1640,7 +1640,9 @@ Parts of this work may be from another specification document.  If so, those par
       <li data-md="">
        <p><a data-link-type="dfn" href="#enumerate-xr-devices" id="ref-for-enumerate-xr-devices">Enumerate XR devices</a>.</p>
       <li data-md="">
-       <p><a data-link-type="dfn" href="#select-a-default-xr-device" id="ref-for-select-a-default-xr-device①">Select a default XR device</a> from the <a data-link-type="dfn" href="#list-of-xr-devices" id="ref-for-list-of-xr-devices⑧">list of XR devices</a>.</p>
+       <p>If the <a data-link-type="dfn" href="#list-of-xr-devices" id="ref-for-list-of-xr-devices⑧">list of XR devices</a> is empty, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror" id="ref-for-notfounderror">NotFoundError</a></code> and abort these steps.</p>
+      <li data-md="">
+       <p><a data-link-type="dfn" href="#select-a-default-xr-device" id="ref-for-select-a-default-xr-device①">Select a default XR device</a> from the <a data-link-type="dfn" href="#list-of-xr-devices" id="ref-for-list-of-xr-devices⑨">list of XR devices</a>.</p>
       <li data-md="">
        <p><a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise">Resolve</a> <var>promise</var> with the <a data-link-type="dfn" href="#default-device" id="ref-for-default-device⑤">default device</a>.</p>
      </ol>
@@ -1682,7 +1684,7 @@ Parts of this work may be from another specification document.  If so, those par
       <li data-md="">
        <p>Let <var>device</var> be the target <code class="idl"><a data-link-type="idl" href="#xrdevice" id="ref-for-xrdevice⑧">XRDevice</a></code> object.</p>
       <li data-md="">
-       <p>If the <var>options</var> are not <a data-link-type="dfn" href="#supported-by-the-device" id="ref-for-supported-by-the-device">supported by the device</a> <var>device</var>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise">reject</a> <var>promise</var> with <code>null</code>.</p>
+       <p>If the <var>options</var> are not <a data-link-type="dfn" href="#supported-by-the-device" id="ref-for-supported-by-the-device">supported by the device</a> <var>device</var>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise①">reject</a> <var>promise</var> with <code>null</code>.</p>
       <li data-md="">
        <p>Else <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise①">resolve</a> <var>promise</var> with <code>null</code>.</p>
      </ol>
@@ -1693,13 +1695,13 @@ Parts of this work may be from another specification document.  If so, those par
       <li data-md="">
        <p>Let <var>device</var> be the target <code class="idl"><a data-link-type="idl" href="#xrdevice" id="ref-for-xrdevice⑨">XRDevice</a></code> object.</p>
       <li data-md="">
-       <p>If the <var>options</var> are not <a data-link-type="dfn" href="#supported-by-the-device" id="ref-for-supported-by-the-device①">supported by the device</a> <var>device</var>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise①">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror" id="ref-for-notsupportederror">NotSupportedError</a></code> and abort these steps.</p>
+       <p>If the <var>options</var> are not <a data-link-type="dfn" href="#supported-by-the-device" id="ref-for-supported-by-the-device①">supported by the device</a> <var>device</var>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise②">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror" id="ref-for-notsupportederror">NotSupportedError</a></code> and abort these steps.</p>
       <li data-md="">
        <p>Let <var>exclusive</var> be the <code class="idl"><a data-link-type="idl" href="#dom-xrsessioncreationoptions-exclusive" id="ref-for-dom-xrsessioncreationoptions-exclusive">exclusive</a></code> attribute of the <var>options</var> argument.</p>
       <li data-md="">
-       <p>If <var>exclusive</var> is <code>true</code> and <var>device</var>’s <a data-link-type="dfn" href="#exclusive-session" id="ref-for-exclusive-session">exclusive session</a> is not <code>null</code>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise②">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code> and abort these steps.</p>
+       <p>If <var>exclusive</var> is <code>true</code> and <var>device</var>’s <a data-link-type="dfn" href="#exclusive-session" id="ref-for-exclusive-session">exclusive session</a> is not <code>null</code>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise③">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror">InvalidStateError</a></code> and abort these steps.</p>
       <li data-md="">
-       <p>If <var>exclusive</var> is <code>true</code> and the algorithm is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation" id="ref-for-triggered-by-user-activation">triggered by user activation</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise③">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror">SecurityError</a></code> and abort these steps.</p>
+       <p>If <var>exclusive</var> is <code>true</code> and the algorithm is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation" id="ref-for-triggered-by-user-activation">triggered by user activation</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise④">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror">SecurityError</a></code> and abort these steps.</p>
       <li data-md="">
        <p>Let <var>session</var> be a new <code class="idl"><a data-link-type="idl" href="#xrsession" id="ref-for-xrsession②">XRSession</a></code>.</p>
       <li data-md="">
@@ -2137,7 +2139,7 @@ xrDevice<span class="p">.</span>requestSession<span class="p">({</span> exclusiv
       <li data-md="">
        <p>Let <var>context</var> be the target <code class="idl"><a data-link-type="idl" href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#webglrenderingcontextbase" id="ref-for-webglrenderingcontextbase②">WebGLRenderingContextBase</a></code> object.</p>
       <li data-md="">
-       <p>If <var>context</var>’s <a data-link-type="dfn" href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-context-lost-flag" id="ref-for-webgl-context-lost-flag">WebGL context lost flag</a> is set, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise④">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror②">InvalidStateError</a></code> and abort these abort these steps.</p>
+       <p>If <var>context</var>’s <a data-link-type="dfn" href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-context-lost-flag" id="ref-for-webgl-context-lost-flag">WebGL context lost flag</a> is set, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise⑤">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror②">InvalidStateError</a></code> and abort these abort these steps.</p>
       <li data-md="">
        <p>If <var>context</var>’s <a data-link-type="dfn" href="#compatible-xr-device" id="ref-for-compatible-xr-device⑥">compatible XR device</a> is <var>device</var>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#resolve-promise" id="ref-for-resolve-promise④">resolve</a> <var>promise</var> and abort these steps.</p>
       <li data-md="">
@@ -2154,7 +2156,7 @@ xrDevice<span class="p">.</span>requestSession<span class="p">({</span> exclusiv
         <li data-md="">
          <p>Force <var>context</var> to be lost and <a data-link-type="dfn" href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#CONTEXT_LOST" id="ref-for-CONTEXT_LOST">handle the context loss</a> as described by the WebGL specification.</p>
         <li data-md="">
-         <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag" id="ref-for-canceled-flag">canceled flag</a> of the "webglcontextlost" event fired in the previous step was not set, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise⑤">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror">AbortError</a></code> and abort these steps.</p>
+         <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#canceled-flag" id="ref-for-canceled-flag">canceled flag</a> of the "webglcontextlost" event fired in the previous step was not set, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise" id="ref-for-reject-promise⑥">reject</a> <var>promise</var> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#aborterror" id="ref-for-aborterror">AbortError</a></code> and abort these steps.</p>
         <li data-md="">
          <p><a data-link-type="dfn" href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#restore-the-drawing-buffer" id="ref-for-restore-the-drawing-buffer">Restore the context</a> on a <a data-link-type="dfn" href="#compatible-graphics-adapter" id="ref-for-compatible-graphics-adapter⑥">compatible graphics adapter</a> for <var>device</var>.</p>
         <li data-md="">
@@ -2637,6 +2639,7 @@ glCanvas<span class="p">.</span>addEventListener<span class="p">(</span><span cl
      <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
      <li><a href="https://heycam.github.io/webidl/#idl-Float32Array">Float32Array</a>
      <li><a href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a>
+     <li><a href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a>
      <li><a href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a>
      <li><a href="https://heycam.github.io/webidl/#SameObject">SameObject</a>
      <li><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>
@@ -2891,7 +2894,7 @@ glCanvas<span class="p">.</span>addEventListener<span class="p">(</span><span cl
   <aside class="dfn-panel" data-for="list-of-xr-devices">
    <b><a href="#list-of-xr-devices">#list-of-xr-devices</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-of-xr-devices">4.1. XR</a> <a href="#ref-for-list-of-xr-devices①">(2)</a> <a href="#ref-for-list-of-xr-devices②">(3)</a> <a href="#ref-for-list-of-xr-devices③">(4)</a> <a href="#ref-for-list-of-xr-devices④">(5)</a> <a href="#ref-for-list-of-xr-devices⑤">(6)</a> <a href="#ref-for-list-of-xr-devices⑥">(7)</a> <a href="#ref-for-list-of-xr-devices⑦">(8)</a> <a href="#ref-for-list-of-xr-devices⑧">(9)</a>
+    <li><a href="#ref-for-list-of-xr-devices">4.1. XR</a> <a href="#ref-for-list-of-xr-devices①">(2)</a> <a href="#ref-for-list-of-xr-devices②">(3)</a> <a href="#ref-for-list-of-xr-devices③">(4)</a> <a href="#ref-for-list-of-xr-devices④">(5)</a> <a href="#ref-for-list-of-xr-devices⑤">(6)</a> <a href="#ref-for-list-of-xr-devices⑥">(7)</a> <a href="#ref-for-list-of-xr-devices⑦">(8)</a> <a href="#ref-for-list-of-xr-devices⑧">(9)</a> <a href="#ref-for-list-of-xr-devices⑨">(10)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="default-device">


### PR DESCRIPTION
Simple change, but one that I want other vendors to LGTM before merging: Had a recent conversation where how we handle the case of not finding a device came up, and it made me question how other similar APIs do it. Previously I had advocated for resolving the promise with `null` in that scenario, but I realized there's prior art here. Turns out that WebUSB and WebBluetooth reject their `requestDevice` calls with a `NotFoundError` when there's no device that matches the given criteria. Therefore, for the sake of consistency on the platform, I feel pretty strongly that WebXR should do the same.

Any complaints?