### PR TITLE
advertise VR functionality -> advertise XR functionality

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -61,7 +61,7 @@ The basic steps most WebXR applications will go through are:
 
 ### Acquiring a Device
 
-The first thing that any XR-enabled page will want to do is request an `XRDevice` and, if one is available, advertise VR functionality to the user. (For example, by adding a button to the page that the user can click to start XR content.)
+The first thing that any XR-enabled page will want to do is request an `XRDevice` and, if one is available, advertise XR functionality to the user. (For example, by adding a button to the page that the user can click to start XR content.)
 
 `navigator.xr.requestDevice` returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to an `XRDevice` if one is available. If no `XRDevice` is available, it will reject with a "NotFoundError". The promise will also be rejected with an appropriate error if an error occurs during the device query. For example, if the page does not have the appropriate permissions to access XR capabilities it would reject with a "NotAllowedError".
 


### PR DESCRIPTION
In the "Acquiring a Device" paragraph of "Lifetime of a VR web app" there is a mention of VR capability whereas it's not an example, thus XR is more generic and should be used here.