### PR TITLE
Renamed pointerOrigin and enum values to reflect usage pattern, not device type.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -399,7 +399,7 @@ function checkMagicWindowSupport() {
 
 XR hardware provides a wide variety of input mechanisms, ranging from single state buttons to fully tracked controllers with multiple buttons, joysticks, triggers, or touchpads. While the intent is to eventually support the full range of available hardware, for the initial version of the WebXR Device API the focus is on enabling a more universal "point and click" style system that can be supported in some capacity by any known XR device and in magic window mode.
 
-In this model every input source has a ray that indicates what is being pointed at, called the "Target Ray", and reports when the primary action for that device has been triggered, surfaced as a "select" event. When the select event is fired the XR application can use the target ray of the input source that generated the event to determine what the user was attempting to interact with and respond accordingly. Additionally, if the input source represents a tracked device a "Grip" matrix will also be provided to indicate where a mesh should be rendered to align with the physical device.~~~
+In this model every input source has a ray that indicates what is being pointed at, called the "Target Ray", and reports when the primary action for that device has been triggered, surfaced as a "select" event. When the select event is fired the XR application can use the target ray of the input source that generated the event to determine what the user was attempting to interact with and respond accordingly. Additionally, if the input source represents a tracked device a "Grip" matrix will also be provided to indicate where a mesh should be rendered to align with the physical device.
 
 ### Enumerating input sources
 
@@ -421,11 +421,11 @@ The properties of an XRInputSource object are immutable. If a device can be mani
 
 Each input source can query a `XRInputPose` using the `getInputPose()` function of any `XRPresentationFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRCoordinateSystem` the pose values should be given in, just like `getDevicePose()`. `getInputPose()` may return `null` in cases where tracking has been lost (similar to `getDevicePose()`), or the given `XRInputSource` instance is no longer connected or available.
 
-If an input source can be tracked the `XRInputPose`'s `gripMatrix` will indicate the device's position and orientation. If only position or orientation is trackable (not both), the `gripMatrix` will return a transform matrix applying only the trackable pose. An example of this case is for physical hands on some AR devices, that only have a tracked position. The `gripMatrix` will be `null` if the input source isn't trackable. 
-
 The `gripMatrix` is a transform into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
 
-An input source will also provide its preferred target ray on its pose, which is defined as a ray originating at `[0, 0, 0]` and extending down the negative Z axis, transformed by the `targetRayMatrix` attribute of an `XRInputPose` object. `pointerMatrix` will never be `null`. Their values will differ based on the type of input source that produces it, which is represented by the `targetRayMode` attribute:
+If the input source has only 3DOF, the grip matrix may represent only a translation or rotation based on tracking capability. An example of this case is for physical hands on some AR devices which only have a tracked position. The `gripMatrix` will be `null` if the input source isn't trackable. 
+
+An input source will also provide its preferred target ray on its pose, which is defined as a ray originating at `[0, 0, 0]` and extending down the negative Z axis, transformed by the `targetRayMatrix` attribute of an `XRInputPose` object. `targetRayMatrix` will never be `null`. The value will differ based on the type of input source that produces it, which is represented by the `targetRayMode` attribute:
 
   * `'gazing'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a grip matrix), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
   * `'pointing'` indicates that the target ray originates from a handheld device and represents that the user is using that device for pointing. The exact orientation of the ray relative to the device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance, the target ray should most likely point in the same direction as the user's index finger if it was outstretched while holding the controller.
@@ -601,7 +601,7 @@ function renderCursor(inputSource, inputPose) {
 }
 ```
 
-### Complex input
+### Grabbing and dragging
 
 While the primary motivation of this input model is a compatible "target and click" interface, more complex interactions such as grabbing and dragging with input sources can also be achieved using only the `select` events.
 

--- a/explainer.md
+++ b/explainer.md
@@ -425,7 +425,7 @@ If an input source can be tracked the `XRInputPose`'s `gripMatrix` will indicate
 
 The `gripMatrix` is a transform into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
 
-An input source will also provide its preferred target ray on its pose, which is defined as a ray originating at position `targetRayOrigin` and extending in the normalized direction `targetRayDirection`. `targetRayOrigin` or `targetRayDirection` will never be `null`. Their values will differ based on the type of input source that produces it, which is represented by the `targetRayMode` attribute:
+An input source will also provide its preferred target ray on its pose, which is defined as a ray originating at `[0, 0, 0]` and extending down the negative Z axis, transformed by the `targetRayMatrix` attribute of an `XRInputPose` object. `pointerMatrix` will never be `null`. Their values will differ based on the type of input source that produces it, which is represented by the `targetRayMode` attribute:
 
   * `'gazing'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a grip matrix), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
   * `'pointing'` indicates that the target ray originates from a handheld device and represents that the user is using that device for pointing. The exact orientation of the ray relative to the device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance, the target ray should most likely point in the same direction as the user's index finger if it was outstretched while holding the controller.
@@ -442,7 +442,7 @@ for (let inputSource of xrInputSources) {
     renderInputSource(session, inputSource, inputPose);
 
     // Highlight any objects that the target ray intersects with
-    let hoveredObject = scene.getObjectIntersectingRay(inputPose.targetRayOrigin, inputPose.targetRayDirection);
+    let hoveredObject = scene.getObjectIntersectingRay(inputPose.targetRayMatrix);
     if (hoveredObject) { 
       // Render a visualization of the object that is highlighted (see below).
       drawHighlightFrom(hovered, inputSource);
@@ -528,7 +528,7 @@ function onSelect(event) {
   let inputPose = event.frame.getInputPose(event.inputSource, xrFrameOfRef);
   if (inputPose) {
     // Ray cast into scene to determine if anything was hit.
-    let selectedObject = scene.getObjectIntersectingRay(inputPose.targetRayOrigin, inputPose.targetRayDirection);
+    let selectedObject = scene.getObjectIntersectingRay(inputPose.targetRayMatrix);
     if (selectedObject) {
       selectedObject.onSelect();
     }
@@ -588,12 +588,12 @@ function renderCursor(inputSource, inputPose) {
   // Only render a target ray if this was the most recently used input source.
   if (inputSource.targetRayMode == "pointing") {
     // Draw targeting rays for pointing devices only.
-    renderer.drawRay(inputPose.targetRayOrigin, inputPose.targetRayDirection);
+    renderer.drawRay(inputPose.targetRayMatrix);
   }
 
   if (inputSource.targetRayMode != "tapping") {
     // Draw a cursor for gazing and pointing devices only.
-    let cursorPosition = scene.getIntersectionPoint(inputPose.targetRayOrigin, inputPose.targetRayDirection);
+    let cursorPosition = scene.getIntersectionPoint(inputPose.targetRayMatrix);
     if (cursorPosition) {
       renderer.drawCursor(cursorPosition);
     }
@@ -627,7 +627,7 @@ function onSelectStart(event) {
     return;
 
   // Use the input source target ray to find a draggable object in the scene
-  let hitResult = scene.hitTest(inputPose.targetRayOrigin, inputPose.targetRayDirection)
+  let hitResult = scene.hitTest(inputPose.targetRayMatrix)
   if (hitResult && hitResult.draggable) {
     // Use the gripMatrix translation to drag the intersected object, rather than the target ray.
     activeDragInteraction = {
@@ -661,7 +661,7 @@ function onUpdateScene() {
 }
 ```
 
-The above sample is optimized for dragging items in the scene around using input sources that have a gripMatrix. It would also be possible to add further script logic to use the targetRay properties to position items in the world - this is left as an exercise for the reader.
+The above sample is optimized for dragging items in the scene around using input sources that have a gripMatrix. It would also be possible to add further script logic to use the target ray properties to position items in the world - this is left as an exercise for the reader.
 
 ### Magic Window Input
 
@@ -1115,8 +1115,7 @@ interface XRInputSource {
 
 interface XRInputPose {
   readonly attribute boolean emulatedPosition;
-  readonly attribute Float32Array targetRayOrigin;
-  readonly attribute Float32Array targetRayDirection;
+  readonly attribute Float32Array targetRayMatrix;
   readonly attribute Float32Array? gripMatrix;
 };
 

--- a/explainer.md
+++ b/explainer.md
@@ -399,11 +399,11 @@ function checkMagicWindowSupport() {
 
 XR hardware provides a wide variety of input mechanisms, ranging from single state buttons to fully tracked controllers with multiple buttons, joysticks, triggers, or touchpads. While the intent is to eventually support the full range of available hardware, for the initial version of the WebXR Device API the focus is on enabling a more universal "point and click" style system that can be supported in some capacity by any known XR device and in magic window mode.
 
-In this model every input source has a ray that indicates what is being pointed at, called the "Pointer Ray", and reports when the primary action for that device has been triggered, surfaced as a "select" event. When the select event is fired the XR application can use the pointer ray of the input source that generated the event to determine what the user was pointing at and respond accordingly. Additionally, if the input source represents a tracked device a "Grip" matrix will also be provided to indicate where a mesh should be rendered to align with the physical device.
+In this model every input source has a ray that indicates what is being pointed at, called the "Target Ray", and reports when the primary action for that device has been triggered, surfaced as a "select" event. When the select event is fired the XR application can use the target ray of the input source that generated the event to determine what the user was attempting to interact with and respond accordingly. Additionally, if the input source represents a tracked device a "Grip" matrix will also be provided to indicate where a mesh should be rendered to align with the physical device.~~~
 
 ### Enumerating input sources
 
-Calling the `getInputSources()` function on an `XRSession` will return a list of all currently available `XRInputSource`s. An `XRInputSource` may represent a tracked controller, inputs built into the headset itself, or more ephemeral input mechanims like tracking of hand gestures. When input sources are added to or removed from the list of available input sources the `inputsourceschange` event will be fired on the `XRSession` object to indicate that any cached copies of the list should be refreshed.
+Calling the `getInputSources()` function on an `XRSession` will return a list of all `XRInputSource`s that the user agent considers active. An `XRInputSource` may represent a tracked controller, inputs built into the headset itself, or more ephemeral input mechanims like tracking of hand gestures. When input sources are added to or removed from the list of available input sources the `inputsourceschange` event will be fired on the `XRSession` object to indicate that any cached copies of the list should be refreshed.
 
 ```js
 // Get the current list of input sources.
@@ -415,17 +415,21 @@ xrSession.addEventListener('inputsourceschange', (ev) => {
 });
 ```
 
+The properties of an XRInputSource object are immutable. If a device can be manipulated in such a way that these properties can change, the `XRInputSource` will be removed and recreated.
+
 ### Input poses
 
-Each input source can queried a `XRInputPose` using the `getInputPose()` function of any `XRPresentationFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRCoordinateSystem` the pose values should be given in, just like `getDevicePose()`. Similar to `getDevicePose()` the requested pose may return `null` in cases where tracking has been lost.
+Each input source can query a `XRInputPose` using the `getInputPose()` function of any `XRPresentationFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRCoordinateSystem` the pose values should be given in, just like `getDevicePose()`. `getInputPose()` may return `null` in cases where tracking has been lost (similar to `getDevicePose()`), or the given `XRInputSource` instance is no longer connected or available.
 
-If an input source can be tracked the `XRInputPose`'s `gripMatrix` will indicate the device's position and orientation. This will be `null` if the input source isn't trackable. The `gripMatrix` is a transform into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
+If an input source can be tracked the `XRInputPose`'s `gripMatrix` will indicate the device's position and orientation. If only position or orientation is trackable (not both), the `gripMatrix` will return a transform matrix applying only the trackable pose. An example of this case is for physical hands on some AR devices, that only have a tracked position. The `gripMatrix` will be `null` if the input source isn't trackable. 
 
-An input source will also provide its preferred pointing ray, which is defined as a ray originating at `[0, 0, 0]` and extending down the negative Z axis, transformed bt the `pointerMatrix` attribute of an `XRInputPose` object. `pointerMatrix` will never be `null`. It's value will differ based on the type of input source that produces it, which is represented by the `pointerOrigin` attribute:
+The `gripMatrix` is a transform into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
 
-  * `'head'` indicates the pointer ray will originate at the user's head and follow the direction they are looking. (This is commonly referred to as a "gaze input" device.) There should be at most one `'head'` input source per session.
-  * `'hand'` indicates that the pointer ray originates from a handheld device, and represents the device's preferred targeting ray. The exact orientation of the ray relative to the device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance, the pointer ray should most likely point in the same direction as the user's index finger if it was outstretched while holding the controller.
-  * `'screen'` indicates that the input source was an interaction with the 2D canvas of a non-exclusive session, such as a mouse click or touch event. See [Magic Window Input](#magic_window_input) for more details.
+An input source will also provide its preferred target ray on its pose, which is defined as a ray originating at position `targetRayOrigin` and extending in the normalized direction `targetRayDirection`. `targetRayOrigin` or `targetRayDirection` will never be `null`. Their values will differ based on the type of input source that produces it, which is represented by the `targetRayMode` attribute:
+
+  * `'gazing'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a grip matrix), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
+  * `'pointing'` indicates that the target ray originates from a handheld device and represents that the user is using that device for pointing. The exact orientation of the ray relative to the device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance, the target ray should most likely point in the same direction as the user's index finger if it was outstretched while holding the controller.
+  * `'tapping'` indicates that the input source was an interaction with the 2D canvas of a non-exclusive session, such as a mouse click or touch event. See [Magic Window Input](#magic_window_input) for more details.
 
 ```js
 // Loop over every input source and get their pose for the current frame.
@@ -435,47 +439,54 @@ for (let inputSource of xrInputSources) {
   // Check to see if the pose is valid
   if (inputPose) {
     // Render a visualization of the input source (see next section).
-    RenderInputSource(inputSource, inputPose);
+    renderInputSource(session, inputSource, inputPose);
 
-    // Highlight any objects that the pointing ray intersects with.
-    // Presumes the use of a fictionalized rendering library.
-    let hoveredObject = scene.getObjectIntersectingRay(inputPose.pointerMatrix);
-    if (hoveredObject) {
-      renderer.drawHighlight(hoveredObject);
+    // Highlight any objects that the target ray intersects with
+    let hoveredObject = scene.getObjectIntersectingRay(inputPose.targetRayOrigin, inputPose.targetRayDirection);
+    if (hoveredObject) { 
+      // Render a visualization of the object that is highlighted (see below).
+      drawHighlightFrom(hovered, inputSource);
     }
   }
 }
 ```
 
-In some cases tracked input sources cannot accurately track their position in space, and provides an estimated position based on the sensor data available to it. This is the case, for example, for the Daydream and GearVR 3DoF controllers, which use an arm model to approximate controller position based on rotation. In these cases the `emulatedPosition` attribute of the `XRInputPose` should be set to `true` to indicate that the translational components of the pose matrices may not be accurate.
-
-### Rendering input sources
-
-Most applications will want to visually represent the input sources somehow. The appropriate type of visualization to be used depends on the value of the `pointerOrigin` attribute:
-
-  * `'head'`: A cursor should be drawn at some distance down the pointer ray, ideally at the depth of the first surface it intersects with, so the user can identify what will be interacted with when a select event is fired. It's not appropriate to draw a controller or ray in this case, since they may obscure the user's vision or be difficult to visually converge on.
-  * `'hand'`: If the `gripMatrix` in not `null` an application-appropriate controller model should be drawn using that matrix as the transform. If appropriate for the experience, the a visualization of the pointer ray and a cursor as described in the `'head'` should also be drawn.
-  * `screen`: Input sources originating from the screen are generated by a mouse, touch, or stylus. In all cases the point of origin of the pointer ray is obvious and no visualization is needed.
+Some platforms may support both tracked and non-tracked input sources concurrently (such as a pair of tracked `'pointing'` 6DOF controllers plus a regular `'gazing'` clicker). Since `xrSession.getInputSources()` returns all connected input sources, an application should take into consideration the most recently used input sources when rendering UI hints, such as a cursor, ray or highlight.
 
 ```js
-// Render a visualization of the input source.
-// Presumes the use of a fictionalized rendering library.
-function RenderInputSource(inputSource, inputPose) {
-  // If the input source is a handheld device with a valid gripMatrix, render
-  // a controller mesh using the gripMatrix as a 
-  if (inputSource.pointerOrigin == "hand" && inputPose.gripMatrix) {
-    let controllerMesh = getControllerMesh();
-    renderer.drawMeshWithTransform(controllerMesh, inputPose.gripMatrix);
+// Keep track of the last-used input source
+var lastInputSource = null;
+
+function onSessionStarted(session) {
+  session.addEventListener("selectstart", event => {
+    // Update the last-used input source
+    lastInputSource = event.inputSource;
+  });
+  session.addEventListener("inputsourceschange", ev => {
+    // Choose an appropriate default from available inputSources, such as prioritizing based on the value of targetRayMode:
+    // 'tapping' over 'pointing' over 'gazing'.
+    lastInputSource = computePreferredInputSource(session.getInputSources());
+  });
+
+  // Remainder of session initialization logic.
+}
+
+function drawHighlightFrom(hoveredObject, inputSource) {
+  // Only highlight meshes that are targeted by the last used input source.
+  if (inputSource == lastInputSource) {
+    // Render a visualization of the highlighted object. (see next section)
+    renderer.drawHighlightFrom(hoveredObject);
   }
+}
 
-  if (inputSource.pointerOrigin != "screen") {
-    // Draw a pointer ray.
-    renderer.drawPointerRayWithTransform(inputPose.pointerMatrix);
-
-    // Draw a cursor.
-    let cursorPosition = scene.getIntersectionPoint();
-    if (cursorPosition) {
-      renderer.drawCursor(cursorPosition);
+// Called by the fictional app/middleware
+function drawScene() {
+  // Display only a single cursor or ray, on the most recently used input source.
+  if (lastInputSource) {
+    let inputPose = xrFrame.getInputPose(lastInputSource, xrFrameOfRef);
+    if (inputPose) {
+      // Render a visualization of the target ray/cursor of the active input source. (see next section)
+      renderCursor(lastInputSource, inputPose)
     }
   }
 }
@@ -516,8 +527,8 @@ function onSessionStarted(session) {
 function onSelect(event) {
   let inputPose = event.frame.getInputPose(event.inputSource, xrFrameOfRef);
   if (inputPose) {
-    // Ray cast into scene with the pointer to determine if anything was hit.
-    let selectedObject = scene.getObjectIntersectingRay(inputPose.pointerPoseMatrix);
+    // Ray cast into scene to determine if anything was hit.
+    let selectedObject = scene.getObjectIntersectingRay(inputPose.targetRayOrigin, inputPose.targetRayDirection);
     if (selectedObject) {
       selectedObject.onSelect();
     }
@@ -525,13 +536,138 @@ function onSelect(event) {
 }
 ```
 
+Some input sources (such as those with a `targetRayMode` of `tapping`) will be only be added to the list of input sources whilst a primary action is occuring. In these cases, the `inputsourceschange` event will fire just prior to the `selectstart` event, then again when the input source is removed after the `selectend` event.
+
 `selectstart` and `selectend` can be useful for handling dragging, painting, or other continuous motions.
+
+In some cases tracked input sources cannot accurately track their position in space, and provides an estimated position based on the sensor data available to it. This is the case, for example, for the Daydream and GearVR 3DoF controllers, which use an arm model to approximate controller position based on rotation. In these cases the `emulatedPosition` attribute of the `XRInputPose` should be set to `true` to indicate that the translational components of the pose matrices may not be accurate.
+
+While most applications will wish to use a targeting ray from the input source pose, it is possible to support only gaze and commit interactions such that the targeting ray always matches the head pose even if trackable controllers are connected. In this case, the `select` event should still be used to handle interaction events, but the device pose can be used to create the targeting ray.
+
+```js
+function onSelect(event) {
+  // Use the device pose to create a ray from the head, regardless of whether controllers are connected.
+  let devicePose = event.frame.getDevicePose(xrFrameOfRef);
+
+  // Ray cast into scene with the device pose to determine if anything was hit.
+  // Assumes the use of a fictionalized math and scene library.
+  let rayOrigin = getTranslation(devicePose.poseModelMatrix);
+  let rayDirection = applyRotation(scene.forwardVector, devicePose.poseModelMatrix);
+  let selectedObject = scene.getObjectIntersectingRay(rayOrigin, rayDirection);
+  if (selectedObject) {
+    selectedObject.onSelect();
+  }
+}
+```
+
+### Rendering input sources
+
+Most applications will want to visually represent the input sources somehow. The appropriate type of visualization to be used depends on the value of the `targetRayMode` attribute:
+
+  * `'gazing'`: A cursor should be drawn at some distance down the target ray, ideally at the depth of the first surface it intersects with, so the user can identify what will be interacted with when a select event is fired. It's not appropriate to draw a controller or ray in this case, since they may obscure the user's vision or be difficult to visually converge on.
+  * `'pointing'`: If the `gripMatrix` in not `null` an application-appropriate controller model should be drawn using that matrix as the transform. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gazing'` should also be drawn.
+  * `'tapping'`: In all cases the point of origin of the target ray is obvious and no visualization is needed.
+
+```js
+// These methods presumes the use of a fictionalized rendering library.
+
+// Render a visualization of the input source - eg. a controller mesh.
+function renderInputSource(session, inputSource, inputPose) {
+  // FIXME: Using a fictional isDisplayOpaque() method to state that controller meshes should not be rendered
+  // on transparent displays (AR).
+  if (isDisplayOpaque(session) && inputPose.gripMatrix) {
+    // Render a controller mesh if the using the gripMatrix as a transform.
+    let controllerMesh = getControllerMesh(inputSource);
+    renderer.drawMeshWithTransform(controllerMesh, inputPose.gripMatrix);
+  }
+}
+
+// Render a visualization of target ray of the input source - eg. a line or cursor.
+// Presumes the use of a fictionalized rendering library.
+function renderCursor(inputSource, inputPose) {
+  // Only render a target ray if this was the most recently used input source.
+  if (inputSource.targetRayMode == "pointing") {
+    // Draw targeting rays for pointing devices only.
+    renderer.drawRay(inputPose.targetRayOrigin, inputPose.targetRayDirection);
+  }
+
+  if (inputSource.targetRayMode != "tapping") {
+    // Draw a cursor for gazing and pointing devices only.
+    let cursorPosition = scene.getIntersectionPoint(inputPose.targetRayOrigin, inputPose.targetRayDirection);
+    if (cursorPosition) {
+      renderer.drawCursor(cursorPosition);
+    }
+  }
+}
+```
+
+### Complex input
+
+While the primary motivation of this input model is a compatible "target and click" interface, more complex interactions such as grabbing and dragging with input sources can also be achieved using only the `select` events.
+
+```js
+// Stores details of an active drag interaction, is any
+let activeDragInteraction = null;
+
+function onSessionStarted(session) {
+  session.addEventListener('selectstart', onSelectStart);
+  session.addEventListener('selectend', onSelectEnd);
+
+  // Remainder of session initialization logic.
+}
+
+function onSelectStart(event) {
+  // Ignore the event if we are already dragging
+  if (activeDragInteraction)
+    return;
+  
+  let inputPose = event.frame.getInputPose(event.inputSource, xrFrameOfRef);
+  // Ignore the event if this input source is not capable of tracking.
+  if (!inputPose || !inputPose.gripMatrix)
+    return;
+
+  // Use the input source target ray to find a draggable object in the scene
+  let hitResult = scene.hitTest(inputPose.targetRayOrigin, inputPose.targetRayDirection)
+  if (hitResult && hitResult.draggable) {
+    // Use the gripMatrix translation to drag the intersected object, rather than the target ray.
+    activeDragInteraction = {
+      target: hitResult,
+      targetStartPosition: hitResult.position,
+      inputSource: event.inputSource,
+      inputSourceStartPosition: getTranslation(inputPose.gripMatrix);
+    };
+  }
+}
+
+// Only end the drag when the input source that started dragging releases the select action
+function onSelectEnd(event) {
+  if (activeDragInteraction && event.inputSource == activeDragInteraction.inputSource)
+    activeDragInteraction = null;
+}
+
+// Called by the fictional app/middleware every frame
+function onUpdateScene() {
+  if (activeDragInteraction) {
+    let inputPose = frame.getInputPose(activeDragInteraction.inputSource, xrFrameOfRef);
+    if (inputPose && inputPose.gripMatrix) {
+      // Determine the vector from the start of the drag to the input source's current position
+      // and position the draggable object accordingly
+      let inputSourcePosition = getTranslation(inputPose.gripMatrix);
+      let deltaPosition = Vector3.subtract(inputSourcePosition, activeDragInteraction.inputSourceStartPosition);
+      let newPosition = Vector3.add(activeDragInteraction.targetStartPosition, deltaPosition);
+      activeDragInteraction.target.setPosition(newPosition);
+    }
+  }
+}
+```
+
+The above sample is optimized for dragging items in the scene around using input sources that have a gripMatrix. It would also be possible to add further script logic to use the targetRay properties to position items in the world - this is left as an exercise for the reader.
 
 ### Magic Window Input
 
 When using a non-exclusive session, pointer events on the canvas that created the `outputContext` passed during the session request are monitored. `XRInputSource`s are generated is response to allow unified input handling with exclusive mode controller or gaze input.
 
-When the canvas receives a `pointerdown` event an `XRInputSource` is created with a `pointerOrigin` of `'screen'` and added to the array returned by `getInputSources()`. A `selectstart` event is then fired on the session with the new `XRInputSource`. The `XRInputSource`'s pointing ray should be updated with every `pointermove` event the canvas receives until a `pointerup` event is received. A `selectend` event is then fired on the session and the `XRInputSource` is removed from the array returned by `getInputSources()`. When the canvas receives a `click` event a `select` event is fired on the session with the appropriate `XRInputSource`.
+When the canvas receives a `pointerdown` event an `XRInputSource` is created with a `targetRayMode` of `'tapping'` and added to the array returned by `getInputSources()`. A `selectstart` event is then fired on the session with the new `XRInputSource`. The `XRInputSource`'s pointing ray should be updated with every `pointermove` event the canvas receives until a `pointerup` event is received. A `selectend` event is then fired on the session and the `XRInputSource` is removed from the array returned by `getInputSources()`. When the canvas receives a `click` event a `select` event is fired on the session with the appropriate `XRInputSource`.
 
 For each of these events the `XRInputSource`'s pointing ray must be updated to originate at the point that was interacted with on the canvas, projected onto the near clipping plane (defined by the `depthNear` attribute of the `XRSession`) and extending out into the scene along that projected vector.
 
@@ -966,20 +1102,21 @@ enum XRHandedness {
   "right"
 };
 
-enum XRPointerOrigin {
-  "head",
-  "hand",
-  "screen"
+enum XRTargetRayMode {
+  "gazing",
+  "pointing",
+  "tapping"
 };
 
 interface XRInputSource {
   readonly attribute XRHandedness handedness;
-  readonly attribute XRPointerOrigin pointerOrigin;
+  readonly attribute XRTargetRayMode targetRayMode;
 };
 
 interface XRInputPose {
   readonly attribute boolean emulatedPosition;
-  readonly attribute Float32Array pointerMatrix;
+  readonly attribute Float32Array targetRayOrigin;
+  readonly attribute Float32Array targetRayDirection;
   readonly attribute Float32Array? gripMatrix;
 };
 

--- a/index.bs
+++ b/index.bs
@@ -697,15 +697,15 @@ enum XRHandedness {
   "right"
 };
 
-enum XRPointerOrigin {
-  "head",
-  "hand",
-  "screen"
+enum XRTargetRayMode {
+  "gazing",
+  "pointing",
+  "tapping"
 };
 
 interface XRInputSource {
   readonly attribute XRHandedness handedness;
-  readonly attribute XRPointerOrigin pointerOrigin;
+  readonly attribute XRTargetRayMode targetRayMode;
 };
 </pre>
 
@@ -717,7 +717,8 @@ XRInputPose {#xrinputpose-interface}
 <pre class="idl">
 interface XRInputPose {
   readonly attribute boolean emulatedPosition;
-  readonly attribute Float32Array pointerMatrix;
+  readonly attribute Float32Array targetRayOrigin;
+  readonly attribute Float32Array targetRayDirection;
   readonly attribute Float32Array? gripMatrix;
 };
 </pre>


### PR DESCRIPTION
The main purpose of this PR is to clarify what input sources are returned from a call to XRSession.getInputSources(). These changes make it easier to expose tracked hands on AR devices are exposed (eg, the HoloLens). 

I've renamed the `pointerOrigin` enum and members to `targetRayMode: { 'gazing', 'pointing', 'tapping' }` to better reflect the input intent, rather than physical representation. This was primarily to reduce confusion: since a tracked hand is actually uses the head gaze as a ray, so should be a `head` not a `hand` in the old nomenclature. 

The implication of this is that while it is up to the user-agent to determine if it is appropriate to merge multiple 0DOF input sources (clicker, gamepad etc.) into a single `gazing` input source, or expose them as multiple (eg, tracked hands that only have a position but not orientation - thus are still considered `gazing`), 
I've removed the responsibility of the user agent for actually choosing which XRInputSource's are 'active'. All available input sources are returned.

~I've also adopted the as-yet unfinalized raycast origin/target, which is under discussion in #339 and immersive-web/hit-test#14. Will need to likely update this when those discussions are resolved.~

Lastly - the controller rendering samples here still depend on the outcome of open issues: #336 and #330 