### PR TITLE
Change how framebufferScaleFactor is interpreted.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -722,7 +722,7 @@ function setupWebGLLayer() {
   });
 ```
 
-In some cases the developer may want to ensure that their application is rendering at the 'native' size for the device. To do this the developer can query the scale factor that should be passed during layer creation with the `XRWebGLLayer.getNativeFramebufferScaleFactor()` function.
+In some cases the developer may want to ensure that their application is rendering at the 'native' size for the device. To do this the developer can query the scale factor that should be passed during layer creation with the `XRWebGLLayer.getNativeFramebufferScaleFactor()` function. (Note that in some cases the native scale may actually be less than the recommended scale of `1.0` if the system is configured to render "superscaled" by default.)
 
 ```js
 function setupNativeScaleWebGLLayer() {
@@ -732,6 +732,8 @@ function setupNativeScaleWebGLLayer() {
     xrSession.baseLayer = new XRWebGLLayer(xrSession, gl, { framebufferScaleFactor: nativeScaleFactor });
   });
 ```
+
+This technique should be used carefully, since the native resolution on some headsets may be higher than the system is capable of rendering at a stable framerate without use of additional techniques such as foveated rendering. Also note that the UA's scale clamping is allowed to prevent the allocation of native resoltion framebuffers if it deems it necessary to maintain acceptable performance.
 
 The second scaling mechanism is to request a scaled viewport into the `XRWebGLLayer`'s `framebuffer`. For example, under times of heavy load the developer may choose to temporarily render fewer pixels. To do so, developers should call `XRWebGLLayer.requestViewportScaling()` and supply a value between 0.0 and 1.0. The UA may then respond by changing the `XRWebGLLayer`'s `framebuffer` and/or the `XRViewport` values in future XR frames. It is worth noting that the UA may change the viewports for reasons other than developer request, and that not all UAs will respect requested viewport changes; as such, developers must always query the viewport values on each XR frame.
 


### PR DESCRIPTION
Addresses #349.

Changes `framebufferScaleFactor` so that a value of 1.0 corresponds to the "default" framebuffer size and exposes a new static `XRWebGLLayer.getNativeFramebufferScaleFactor(xrSession)` function that reports the scale that should be used to get a 1:1 pixel ratio.