### PR TITLE
Unbind the framebuffer when the session ends.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -228,7 +228,7 @@ function onDrawFrame(timestamp, xrFrame) {
   // Do we have an active session?
   if (xrSession) {
     let pose = xrFrame.getDevicePose(xrFrameOfRef);
-    gl.bindFramebuffer(xrSession.baseLayer.framebuffer);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, xrSession.baseLayer.framebuffer);
 
     for (let view of xrFrame.views) {
       let viewport = xrSession.baseLayer.getViewport(view);
@@ -306,6 +306,8 @@ function endXRSession() {
 
 // Restore the page to normal after exclusive access has been released.
 function onSessionEnd() {
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
   xrSession = null;
 
   // Ending the session stops executing callbacks passed to the XRSession's


### PR DESCRIPTION
If you're reusing the same canvas with the same context to render
the content inside the page you want to tell to unbind it from
the XRWebGLLayer. Not doing triggers warning in Chrome :

WebGL : INVALID_FRAMEBUFFER_OPERATION: cannot render to a WebVR
layer outside of a frame callback.