### PR TITLE
Change tense of XRTargetRayMode enums

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -426,7 +426,7 @@ An input source will also provide its preferred target ray on its pose, which is
 
   * `'gaze'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a grip matrix), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
   * `'handheld'` indicates that the target ray originates from a handheld device and represents that the user is using that device for pointing. The exact orientation of the ray relative to the device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance, the target ray should most likely point in the same direction as the user's index finger if it was outstretched while holding the controller.
-  * `'canvas'` indicates that the input source was an interaction with the 2D canvas of a non-immersive session, such as a mouse click or touch event. See [Magic Window Input](#magic_window_input) for more details.
+  * `'screen'` indicates that the input source was an interaction with the canvas element associated with a non-immersive session's output context, such as a mouse click or touch event. See [Magic Window Input](#magic_window_input) for more details.
 
 ```js
 // Loop over every input source and get their pose for the current frame.
@@ -461,7 +461,7 @@ function onSessionStarted(session) {
   });
   session.addEventListener("inputsourceschange", ev => {
     // Choose an appropriate default from available inputSources, such as prioritizing based on the value of targetRayMode:
-    // 'canvas' over 'handheld' over 'gaze'.
+    // 'screen' over 'handheld' over 'gaze'.
     lastInputSource = computePreferredInputSource(session.getInputSources());
   });
 
@@ -533,7 +533,7 @@ function onSelect(event) {
 }
 ```
 
-Some input sources (such as those with a `targetRayMode` of `canvas`) will be only be added to the list of input sources whilst a primary action is occuring. In these cases, the `inputsourceschange` event will fire just prior to the `selectstart` event, then again when the input source is removed after the `selectend` event.
+Some input sources (such as those with a `targetRayMode` of `screen`) will be only be added to the list of input sources whilst a primary action is occuring. In these cases, the `inputsourceschange` event will fire just prior to the `selectstart` event, then again when the input source is removed after the `selectend` event.
 
 `selectstart` and `selectend` can be useful for handling dragging, painting, or other continuous motions.
 
@@ -563,7 +563,7 @@ Most applications will want to visually represent the input sources somehow. The
 
   * `'gaze'`: A cursor should be drawn at some distance down the target ray, ideally at the depth of the first surface it intersects with, so the user can identify what will be interacted with when a select event is fired. It's not appropriate to draw a controller or ray in this case, since they may obscure the user's vision or be difficult to visually converge on.
   * `'handheld'`: If the `gripMatrix` in not `null` an application-appropriate controller model should be drawn using that matrix as the transform. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
-  * `'canvas'`: In all cases the point of origin of the target ray is obvious and no visualization is needed.
+  * `'screen'`: In all cases the point of origin of the target ray is obvious and no visualization is needed.
 
 ```js
 // These methods presumes the use of a fictionalized rendering library.
@@ -588,7 +588,7 @@ function renderCursor(inputSource, inputPose) {
     renderer.drawRay(inputPose.targetRayMatrix);
   }
 
-  if (inputSource.targetRayMode != "canvas") {
+  if (inputSource.targetRayMode != 'screen') {
     // Draw a cursor for gazing and handheld devices only.
     let cursorPosition = scene.getIntersectionPoint(inputPose.targetRayMatrix);
     if (cursorPosition) {
@@ -664,7 +664,7 @@ The above sample is optimized for dragging items in the scene around using input
 
 When using a non-immersive session, pointer events on the canvas that created the `outputContext` passed during the session request are monitored. `XRInputSource`s are generated in response to allow unified input handling with immersive mode controller or gaze input.
 
-When the canvas receives a `pointerdown` event an `XRInputSource` is created with a `targetRayMode` of `'canvas'` and added to the array returned by `getInputSources()`. A `selectstart` event is then fired on the session with the new `XRInputSource`. The `XRInputSource`'s target ray should be updated with every `pointermove` event the canvas receives until a `pointerup` event is received. A `selectend` event is then fired on the session and the `XRInputSource` is removed from the array returned by `getInputSources()`. When the canvas receives a `click` event a `select` event is fired on the session with the appropriate `XRInputSource`.
+When the canvas receives a `pointerdown` event an `XRInputSource` is created with a `targetRayMode` of `'screen'` and added to the array returned by `getInputSources()`. A `selectstart` event is then fired on the session with the new `XRInputSource`. The `XRInputSource`'s target ray should be updated with every `pointermove` event the canvas receives until a `pointerup` event is received. A `selectend` event is then fired on the session and the `XRInputSource` is removed from the array returned by `getInputSources()`. When the canvas receives a `click` event a `select` event is fired on the session with the appropriate `XRInputSource`.
 
 For each of these events the `XRInputSource`'s target ray must be updated to originate at the point that was interacted with on the canvas, projected onto the near clipping plane (defined by the `depthNear` attribute of the `XRSession`) and extending out into the scene along that projected vector.
 
@@ -1165,7 +1165,7 @@ enum XRHandedness {
 enum XRTargetRayMode {
   "gaze",
   "handheld",
-  "canvas"
+  "screen"
 };
 
 interface XRInputSource {

--- a/explainer.md
+++ b/explainer.md
@@ -425,7 +425,7 @@ If the input source has only 3DOF, the grip matrix may represent only a translat
 An input source will also provide its preferred target ray on its pose, which is defined as a ray originating at `[0, 0, 0]` and extending down the negative Z axis, transformed by the `targetRayMatrix` attribute of an `XRInputPose` object. `targetRayMatrix` will never be `null`. The value will differ based on the type of input source that produces it, which is represented by the `targetRayMode` attribute:
 
   * `'gaze'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a grip matrix), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
-  * `'tracked-hand'` indicates that the target ray originates from either a handheld device or other hand-tracking mechanism and represents that the user is using their hands or the held device for pointing. The exact orientation of the ray relative to a given device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance or a physical device, the target ray should most likely point in the same direction as the user's index finger if it was outstretched.
+  * `'tracked-pointer'` indicates that the target ray originates from either a handheld device or other hand-tracking mechanism and represents that the user is using their hands or the held device for pointing. The exact orientation of the ray relative to a given device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance or a physical device, the target ray should most likely point in the same direction as the user's index finger if it was outstretched.
   * `'screen'` indicates that the input source was an interaction with the canvas element associated with a non-immersive session's output context, such as a mouse click or touch event. See [Magic Window Input](#magic_window_input) for more details.
 
 ```js
@@ -448,7 +448,7 @@ for (let inputSource of xrInputSources) {
 }
 ```
 
-Some platforms may support both tracked and non-tracked input sources concurrently (such as a pair of tracked `'tracked-hand'` 6DOF controllers plus a regular `'gaze'` clicker). Since `xrSession.getInputSources()` returns all connected input sources, an application should take into consideration the most recently used input sources when rendering UI hints, such as a cursor, ray or highlight.
+Some platforms may support both tracked and non-tracked input sources concurrently (such as a pair of `'tracked-pointer'` 6DOF controllers plus a regular `'gaze'` clicker). Since `xrSession.getInputSources()` returns all connected input sources, an application should take into consideration the most recently used input sources when rendering UI hints, such as a cursor, ray or highlight.
 
 ```js
 // Keep track of the last-used input source
@@ -461,7 +461,7 @@ function onSessionStarted(session) {
   });
   session.addEventListener("inputsourceschange", ev => {
     // Choose an appropriate default from available inputSources, such as prioritizing based on the value of targetRayMode:
-    // 'screen' over 'tracked-hand' over 'gaze'.
+    // 'screen' over 'tracked-pointer' over 'gaze'.
     lastInputSource = computePreferredInputSource(session.getInputSources());
   });
 
@@ -562,7 +562,7 @@ function onSelect(event) {
 Most applications will want to visually represent the input sources somehow. The appropriate type of visualization to be used depends on the value of the `targetRayMode` attribute:
 
   * `'gaze'`: A cursor should be drawn at some distance down the target ray, ideally at the depth of the first surface it intersects with, so the user can identify what will be interacted with when a select event is fired. It's not appropriate to draw a controller or ray in this case, since they may obscure the user's vision or be difficult to visually converge on.
-  * `'tracked-hand'`: If the `gripMatrix` in not `null` an application-appropriate controller model should be drawn using that matrix as the transform. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
+  * `'tracked-pointer'`: If the `gripMatrix` in not `null` an application-appropriate controller model should be drawn using that matrix as the transform. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
   * `'screen'`: In all cases the point of origin of the target ray is obvious and no visualization is needed.
 
 ```js
@@ -583,13 +583,13 @@ function renderInputSource(session, inputSource, inputPose) {
 // Presumes the use of a fictionalized rendering library.
 function renderCursor(inputSource, inputPose) {
   // Only render a target ray if this was the most recently used input source.
-  if (inputSource.targetRayMode == "tracked-hand") {
-    // Draw targeting rays for tracked-hand devices only.
+  if (inputSource.targetRayMode == "tracked-pointer") {
+    // Draw targeting rays for tracked-pointer devices only.
     renderer.drawRay(inputPose.targetRayMatrix);
   }
 
   if (inputSource.targetRayMode != 'screen') {
-    // Draw a cursor for gazing and tracked-hand devices only.
+    // Draw a cursor for gazing and tracked-pointer devices only.
     let cursorPosition = scene.getIntersectionPoint(inputPose.targetRayMatrix);
     if (cursorPosition) {
       renderer.drawCursor(cursorPosition);
@@ -1164,7 +1164,7 @@ enum XRHandedness {
 
 enum XRTargetRayMode {
   "gaze",
-  "tracked-hand",
+  "tracked-pointer",
   "screen"
 };
 

--- a/index.bs
+++ b/index.bs
@@ -721,9 +721,9 @@ enum XRHandedness {
 };
 
 enum XRTargetRayMode {
-  "gazing",
-  "pointing",
-  "tapping"
+  "gaze",
+  "handheld",
+  "canvas"
 };
 
 interface XRInputSource {

--- a/index.bs
+++ b/index.bs
@@ -722,8 +722,8 @@ enum XRHandedness {
 
 enum XRTargetRayMode {
   "gaze",
-  "handheld",
-  "canvas"
+  "tracked-pointer",
+  "screen"
 };
 
 interface XRInputSource {


### PR DESCRIPTION
I've gotten feedback from a couple of sources now that the naming for the `XRTargetRayMode` enums goes against the grain of web platform conventions a bit, specifically the "*ing" tense that they use. In the words of @bfgeek:

> The *ing names are a little out of place... It would probably make sense if the *ing were part of a state machine, e.g. "loading" an url. -> "loaded" an url. (see also "pending" etc.).
>
> closest thing we have on the web is pointerEvents.pointerType, which just uses "touch", "mouse", etc.

Of course, as @leweaver [remarked on the original pull request](https://github.com/immersive-web/webxr/pull/342#discussion_r190438762) "Naming is hard, yo." (@leweaver quotes may be paraphrased.)

So I'd like to discuss some alternatives, and an priming that conversation with some suggestions of my own:

 - `gazing`->`gaze`: This is the easy one, as the term "gaze" already has strong associations within the VR community and it accomplishes the goal of describing the intent instead of the mechanism behind it. As such simply dropping the "ing" feels sufficient.
 - `pointing`->`handheld`: I'm less sure about this and super happy to discuss alternatives. Simply dropping the "ing" to get `point` feels confusing (wait, is it a ray or a point?). `hand` seems like it could be appropriate as well, but that was the original term that we moved away from because in some cases hand gestures will actually produce `gaze` inputs. (Then again, we could argue that this should represent intent and that target rays with a `hand` mode do, indeed, intend to represent hands.) `handheld` more explicitly suggests something like a controller, but that could be confusing as well since a bluetooth clicker-style input would likely be handheld but also produce gaze input. Similarly, Leap Motion-style hand tracking would probably fall into this category, but categorizing that as `handheld` makes it sound like you're holding your own hands in your hands. 😵 In the end I went with this simply because it's how Lewis' text refers to this style of input: "indicates the target ray originates from a handheld device and represents that the user is using that device for pointing."
 - `tapping`->`canvas`: I wasn't a fan of `tapping` because it felt highly touch-centric when the inputs may also originate from mouse cursors, stylus, or virtual pointers in a VR browser, but didn't have a better suggestion at the time. Again, Lewis' text informed the suggested alternative: "indicates that the input source was an interaction with the 2D canvas". At the risk of drifting away from the inputs intent and more towards the mechanics that produce it, this feels like a more accurate classification of the input in question because it is produced by and originating from the canvas element.

To be clear, I don't feel anything else about the original input renaming needs updating. I like the intent behind it, the new explanatory text, and the terminology of "TargetRay" rather than "Pointer". If we're going to change the enums, however, I feel like it would be best to lock it down soon so we don't have the names we're discarding out in the wild for very long.
