### PR TITLE
Move Views array to Pose

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -133,7 +133,7 @@ If `supportsSessionMode` resolved for a given mode, then requesting a session wi
 Only one immersive session per XR hardware device is allowed at a time across the entire UA. All inline sessions are suspended when an immersive session is active. Inline sessions are not required to be created within a user activation event unless paired with another option that explicitly does require it.
 
 Once the session has started, some setup must be done to prepare for rendering.
-- A `XRFrameOfReference` should be created to establish a coordinate system in which `XRDevicePose` data will be defined. See the [Spatial Tracking Explainer](spatial-tracking-explainer.md) for more information.
+- A `XRFrameOfReference` should be created to establish a coordinate system in which `XRViewerPose` data will be defined. See the [Spatial Tracking Explainer](spatial-tracking-explainer.md) for more information.
 - A `XRLayer` must be created and assigned to the `XRSession`'s `baseLayer` attribute. (`baseLayer` because future versions of the spec will likely enable multiple layers, at which point this would act like the `firstChild` attribute of a DOM element.)
 - Then `XRSession.requestAnimationFrame` must be called to start the render loop pumping.
 
@@ -195,7 +195,7 @@ If the system's underlying XR device changes (signaled by the `devicechange` eve
 
 ### Main render loop
 
-The WebXR Device API provides information about the current frame to be rendered via the `XRFrame` object which developers must examine each iteration of the render loop. The `XRDevicePose` contains the information about all views which must be rendered and targets into which this rendering must be done.
+The WebXR Device API provides information about the current frame to be rendered via the `XRFrame` object which developers must examine each iteration of the render loop. From this object the frame's `XRViewerPose` can be queried, which contains the information about all the views which must be rendered in order for the scene to display correctly on the XR device.
 
 `XRWebGLLayer` objects are not updated automatically. To present new frames, developers must use `XRSession`'s `requestAnimationFrame()` method. When the callback function is run, it is passed both a timestamp and an `XRFrame` containing fresh rendering data that must be used to draw into the `XRWebGLLayer`s `framebuffer` during the callback.
 
@@ -205,19 +205,19 @@ The `XRWebGLLayer`s framebuffer is created by the UA and behaves similarly to a 
 
 Once drawn to, the XR device will continue displaying the contents of the `XRWebGLLayer` framebuffer, potentially reprojected to match head motion, regardless of whether or not the page continues processing new frames. Potentially future spec iterations could enable additional types of layers, such as video layers, that could automatically be synchronized to the device's refresh rate.
 
-To get view matrices or the `poseModelMatrix` for each `XRFrame`, developers must call `getDevicePose()` and provide an `XRFrameOfReference` in which these matrices should be returned. Due to the nature of XR tracking systems, this function is not guaranteed to return a value and developers will need to respond appropriately.  For more information about what situations will cause `getDevicePose()` to fail and recommended practices for handling the situation, refer to the [Spatial Tracking Explainer](spatial-tracking-explainer.md).
+To get view matrices or the `poseMatrix` for each `XRFrame`, developers must call `getViewerPose()` and provide an `XRFrameOfReference` in which these matrices should be returned. Due to the nature of XR tracking systems, this function is not guaranteed to return a value and developers will need to respond appropriately.  For more information about what situations will cause `getViewerPose()` to fail and recommended practices for handling the situation, refer to the [Spatial Tracking Explainer](spatial-tracking-explainer.md).
 
 ```js
 function onDrawFrame(timestamp, xrFrame) {
   // Do we have an active session?
   if (xrSession) {
-    let pose = xrFrame.getDevicePose(xrFrameOfRef);
+    let pose = xrFrame.getViewerPose(xrFrameOfRef);
     gl.bindFramebuffer(gl.FRAMEBUFFER, xrSession.baseLayer.framebuffer);
 
-    for (let view of xrFrame.views) {
+    for (let view of pose.views) {
       let viewport = xrSession.baseLayer.getViewport(view);
       gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height);
-      drawScene(view, pose);
+      drawScene(view);
     }
 
     // Request the next animation callback
@@ -232,11 +232,11 @@ function onDrawFrame(timestamp, xrFrame) {
   }
 }
 
-function drawScene(view, pose) {
+function drawScene(view) {
   let viewMatrix = null;
   let projectionMatrix = null;
   if (view) {
-    viewMatrix = pose.getViewMatrix(view);
+    viewMatrix = pose.viewMatrix;
     projectionMatrix = view.projectionMatrix;
   } else {
     viewMatrix = defaultViewMatrix;
@@ -499,7 +499,7 @@ function drawScene() {
 ## Appendix A: I don’t understand why this is a new API. Why can’t we use…
 
 ### `DeviceOrientation` Events
-The data provided by an `XRDevicePose` instance is similar to the data provided by the non-standard `DeviceOrientationEvent`, with some key differences:
+The data provided by an `XRViewerPose` instance is similar to the data provided by the non-standard `DeviceOrientationEvent`, with some key differences:
 
 * It’s an explicit polling interface, which ensures that new input is available for each frame. The event-driven `DeviceOrientation` data may skip a frame, or may deliver two updates in a single frame, which can lead to disruptive, jittery motion in an XR application.
 * `DeviceOrientation` events do not provide positional data, which is a key feature of high-end XR hardware.
@@ -594,10 +594,9 @@ enum XREnvironmentBlendMode {
 
 [SecureContext, Exposed=Window] interface XRFrame {
   readonly attribute XRSession session;
-  readonly attribute FrozenArray<XRView> views;
 
   // Also listed in the spatial-tracking-explainer.md
-  XRDevicePose? getDevicePose(optional XRFrameOfReference frameOfReference);
+  XRViewerPose? getViewerPose(optional XRFrameOfReference frameOfReference);
   XRInputPose? getInputPose(XRInputSource inputSource, optional XRFrameOfReference frameOfReference);
 };
 
@@ -609,6 +608,12 @@ enum XREye {
 [SecureContext, Exposed=Window] interface XRView {
   readonly attribute XREye eye;
   readonly attribute Float32Array projectionMatrix;
+  readonly attribute Float32Array viewMatrix;
+};
+
+[SecureContext, Exposed=Window] interface XRViewerPose {
+  readonly attribute Float32Array poseMatrix;
+  readonly attribute FrozenArray<XRView> views;
 };
 
 [SecureContext, Exposed=Window] interface XRViewport {
@@ -616,12 +621,6 @@ enum XREye {
   readonly attribute long y;
   readonly attribute long width;
   readonly attribute long height;
-};
-
-[SecureContext, Exposed=Window] interface XRDevicePose {
-  readonly attribute Float32Array poseModelMatrix;
-  
-  Float32Array getViewMatrix(XRView view);
 };
 
 //

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -25,7 +25,7 @@ The properties of an XRInputSource object are immutable. If a device can be mani
 
 ### Input poses
 
-Each input source can query a `XRInputPose` using the `getInputPose()` function of any `XRFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRFrameOfReference` the pose values should be given in, just like `getDevicePose()`. `getInputPose()` may return `null` in cases where tracking has been lost (similar to `getDevicePose()`), or the given `XRInputSource` instance is no longer connected or available.
+Each input source can query a `XRInputPose` using the `getInputPose()` function of any `XRFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRFrameOfReference` the pose values should be given in, just like `getViewerPose()`. `getInputPose()` may return `null` in cases where tracking has been lost (similar to `getViewerPose()`), or the given `XRInputSource` instance is no longer connected or available.
 
 The `gripMatrix` is a transform into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
 
@@ -122,7 +122,7 @@ A `select` event indicates that a primary action has been completed. `select` ev
 
 For primary actions that are instantaneous without a clear start and end point (such as a verbal command), all three events should still fire in the sequence `selectstart`, `selectend`, `select`.
 
-All three events are `XRInputSourceEvent` events. When fired the event's `inputSource` attribute must contain the `XRInputSource` that produced the event. The event's `frame` attribute must contain a valid `XRFrame` that can be used to query the input and device poses at the time the selection event occurred. The `XRFrame`'s `views` array must be empty.
+All three events are `XRInputSourceEvent` events. When fired the event's `inputSource` attribute must contain the `XRInputSource` that produced the event. The event's `frame` attribute must contain a valid `XRFrame` that can be used to query the input and device poses at the time the selection event occurred. The `XRViewerPose`'s `views` array must be empty.
 
 In most cases applications will only need to listen for the `select` event for basic interactions like clicking on buttons.
 
@@ -156,13 +156,13 @@ While most applications will wish to use a targeting ray from the input source p
 
 ```js
 function onSelect(event) {
-  // Use the device pose to create a ray from the head, regardless of whether controllers are connected.
-  let devicePose = event.frame.getDevicePose(xrFrameOfRef);
+  // Use the viewer pose to create a ray from the head, regardless of whether controllers are connected.
+  let viewerPose = event.frame.getViewerPose(xrFrameOfRef);
 
-  // Ray cast into scene with the device pose to determine if anything was hit.
+  // Ray cast into scene with the viewer pose to determine if anything was hit.
   // Assumes the use of a fictionalized math and scene library.
-  let rayOrigin = getTranslation(devicePose.poseModelMatrix);
-  let rayDirection = applyRotation(scene.forwardVector, devicePose.poseModelMatrix);
+  let rayOrigin = getTranslation(viewerPose.poseMatrix);
+  let rayDirection = applyRotation(scene.forwardVector, viewerPose.poseMatrix);
   let selectedObject = scene.getObjectIntersectingRay(rayOrigin, rayDirection);
   if (selectedObject) {
     selectedObject.onSelect();


### PR DESCRIPTION
Addresses the core issue of #412, though there's room for a follow up if we decide that having a default frame of reference is a good idea.

This PR makes the relatively simple change of moving the `views` array off of the `XRFrame` and under the queried pose, so that projection matricies that take into account the frame of reference if necessary. In my opinion this also simplifies the common case code a little bit and leaves less questions about why the various matrices are spread across the various interfaces instead of all in once place.

I've also taken the opportunity to rename the pose from `XRDevicePose` to `XRViewerPose`, taking a page from [@thetuvix's suggestion](https://github.com/immersive-web/webxr/issues/412#issuecomment-429583278). I'm happy to take additional naming suggestions, but "Viewer" feels appropriate because it doesn't ascribe the pose to a specific piece of hardware, as that may not be accurate in some cases (CAVE/zSpace, for example). Instead it suggests that in all cases the pose is associated with the person/thing that is viewing the scene. "Camera" may be another alternative, but seems like it has the potential to be confused for the cameras that are actually doing the tracking/passthrough on some devices.