### PR TITLE
Added session feature handling to the explainer.

### DIFF
--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -212,11 +212,12 @@ function onSessionStarted(session) {
 }
 ```
 
-While many sites will be able to provide this fallback, for some sites this will not be possible.  Under these circumstances, it is instead preferable for session creation to reject rather than spin up immersive display/tracking systems only to immediately exit the session.
+While many sites will be able to provide this fallback, for some sites this will not be possible.  Under these circumstances, it is instead preferable for session creation to reject rather than spin up immersive display/tracking systems only to immediately exit the session. To make session creation contingent on support for a specific reference space types, pass the types as an array to the `XRSessionCreationOptions` dictionary's `requiredReferenceSpaceTypes` value. When given, the session request will only succeed if at least one of the specified types are supported.
 
 ```js
 function beginImmersiveSession() {
-  xrDevice.requestSession({ immersive: true,  requiredReferenceSpaceType:'unbounded' })
+  xrDevice.requestSession({ immersive: true, 
+                            requiredReferenceSpaceTypes:['unbounded', 'bounded'] })
       .then(onSessionStarted)
       .catch(err => {
         // Error will indicate required reference space type unavailable
@@ -316,7 +317,7 @@ This is a partial IDL and is considered additive to the core IDL found in the ma
 //
 
 partial dictionary XRSessionCreationOptions {
-  XRReferenceSpaceType requiredReferenceSpaceType;
+  sequence<XRReferenceSpaceTypes> requiredReferenceSpaceTypes;
 };
 
 partial interface XRSession {


### PR DESCRIPTION
Addresses #423 and #424.

A couple of key points that aren't explicitly stated here:

 - Checking with @bfgeek, it sounds like passing the "desired" feature list as string and mapping them to the feature enum is a reasonable way of avoiding errors on unrecognized enums. Hence the difference in the IDL between the desired and required sets.
 - Since the desired behavior for requiring frames of reference is "or" logic, which is different than every other expected feature, this PR leaves the existing `requiredFrameOfReferenceTypes` dictionary key alone.

Finally, this PR is obviously using a "filler feature" to demonstrate the API, since we don't have any other real features decided on yet. I would like to establish this as the expected method for handling these features now, but effectively mark it as "unimplemented" until we have features that will actually make use of it. (I'd need to update the PR to show that prior to landing.)