### PR TITLE
Rename CoordinateSystem/FrameOfReference => Space/ReferenceSpace

### DIFF
--- a/input-explainer.md
+++ b/input-explainer.md
@@ -25,7 +25,7 @@ The properties of an XRInputSource object are immutable. If a device can be mani
 
 ### Input poses
 
-Each input source can query a `XRInputPose` using the `getInputPose()` function of any `XRFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRFrameOfReference` the pose values should be given in, just like `getViewerPose()`. `getInputPose()` may return `null` in cases where tracking has been lost (similar to `getViewerPose()`), or the given `XRInputSource` instance is no longer connected or available.
+Each input source can query a `XRInputPose` using the `getInputPose()` function of any `XRFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRReferenceSpace` the pose values should be given in, just like `getViewerPose()`. `getInputPose()` may return `null` in cases where tracking has been lost (similar to `getViewerPose()`), or the given `XRInputSource` instance is no longer connected or available.
 
 The `gripMatrix` is a transform into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
 
@@ -42,7 +42,7 @@ The `targetRay` will never be `null`. It's value will differ based on the type o
 ```js
 // Loop over every input source and get their pose for the current frame.
 for (let inputSource of xrInputSources) {
-  let inputPose = xrFrame.getInputPose(inputSource, xrFrameOfRef);
+  let inputPose = xrFrame.getInputPose(inputSource, xrReferenceSpace);
 
   // Check to see if the pose is valid
   if (inputPose) {
@@ -92,7 +92,7 @@ function drawHighlightFrom(hoveredObject, inputSource) {
 function drawScene() {
   // Display only a single cursor or ray, on the most recently used input source.
   if (lastInputSource) {
-    let inputPose = xrFrame.getInputPose(lastInputSource, xrFrameOfRef);
+    let inputPose = xrFrame.getInputPose(lastInputSource, xrReferenceSpace);
     if (inputPose) {
       // Render a visualization of the target ray/cursor of the active input source. (see next section)
       renderCursor(lastInputSource, inputPose)
@@ -134,7 +134,7 @@ function onSessionStarted(session) {
 }
 
 function onSelect(event) {
-  let inputPose = event.frame.getInputPose(event.inputSource, xrFrameOfRef);
+  let inputPose = event.frame.getInputPose(event.inputSource, xrReferenceSpace);
   if (inputPose) {
     // Ray cast into scene to determine if anything was hit.
     let ray = inputPose.targetRay;
@@ -157,7 +157,7 @@ While most applications will wish to use a targeting ray from the input source p
 ```js
 function onSelect(event) {
   // Use the viewer pose to create a ray from the head, regardless of whether controllers are connected.
-  let viewerPose = event.frame.getViewerPose(xrFrameOfRef);
+  let viewerPose = event.frame.getViewerPose(xrReferenceSpace);
 
   // Ray cast into scene with the viewer pose to determine if anything was hit.
   // Assumes the use of a fictionalized math and scene library.
@@ -233,7 +233,7 @@ function onSelectStart(event) {
   if (activeDragInteraction)
     return;
   
-  let inputPose = event.frame.getInputPose(event.inputSource, xrFrameOfRef);
+  let inputPose = event.frame.getInputPose(event.inputSource, xrReferenceSpace);
   // Ignore the event if this input source is not capable of tracking.
   if (!inputPose || !inputPose.gripMatrix)
     return;
@@ -261,7 +261,7 @@ function onSelectEnd(event) {
 // Called by the fictional app/middleware every frame
 function onUpdateScene() {
   if (activeDragInteraction) {
-    let inputPose = frame.getInputPose(activeDragInteraction.inputSource, xrFrameOfRef);
+    let inputPose = frame.getInputPose(activeDragInteraction.inputSource, xrReferenceSpace);
     if (inputPose && inputPose.gripMatrix) {
       // Determine the vector from the start of the drag to the input source's current position
       // and position the draggable object accordingly
@@ -306,7 +306,7 @@ partial interface XRSession {
 
 partial interface XRFrame {
   // Also listed in the spatial-tracking-explainer.md
-  XRInputPose? getInputPose(XRInputSource inputSource, optional XRFrameOfReference frameOfReference);
+  XRInputPose? getInputPose(XRInputSource inputSource, optional XRReferenceSpace referenceSpace);
 };
 
 //

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -4,14 +4,14 @@ This document is a subsection of the main WebXR Device API explainer document wh
 ## Introduction
 A big differentiating aspect of XR, as opposed to standard 3D rendering, is that users control the view of the experience via their body motion.  To make this possible, XR hardware needs to be capable of tracking the user's motion in 3D space.  Within the XR ecosystem there is a wide range of hardware form factors and capabilities which have historically only been available to developers through device-specific SDKs and app platforms. To ship software in a specific app store, developers optimize their experiences for specific VR hardware (HTC Vive, GearVR, Mirage Solo, etc) or AR hardware (HoloLens, ARKit, ARCore, etc).  WebXR  development is fundamentally different in that regard; the Web gives developers broader reach, with the consequence that they no longer have predictability about the capability of the hardware their experiences will be running on.
 
-## Frames of Reference
-The wide range of hardware form factors makes it impractical and unscalable to expect developers to reason directly about the tracking technology their experience will be running on.  Instead, the WebXR Device API is designed to have developers think upfront about the mobility needs of the experience they are building which is communicated to the User Agent by explicitly requesting an appropriate `XRFrameOfReference`.  The `XRFrameOfReference` object acts as a substrate for the XR experience being built by establishing guarantees about supported motion and providing a coordinate system in which developers can retrieve `XRViewerPose` and it's view matrices.  The critical aspect to note is that the User Agent (or underlying platform) is responsible for providing consistently behaved lower-capability `XRFrameOfReference` objects even when running on a higher-capability tracking system. 
+## Reference Spaces
+The wide range of hardware form factors makes it impractical and unscalable to expect developers to reason directly about the tracking technology their experience will be running on.  Instead, the WebXR Device API is designed to have developers think upfront about the mobility needs of the experience they are building which is communicated to the User Agent by explicitly requesting an appropriate `XRReferenceSpace`.  The `XRReferenceSpace` object acts as a substrate for the XR experience being built by establishing guarantees about supported motion and providing a space in which developers can retrieve `XRViewerPose` and it's view matrices.  The critical aspect to note is that the User Agent (or underlying platform) is responsible for providing consistently behaved lower-capability `XRReferenceSpace` objects even when running on a higher-capability tracking system. 
 
-There are three types of frames of reference: `bounded`, `unbounded`, and `stationary`.  A bounded experience is one in which the user will move around their physical environment to fully interact, but will not need to travel beyond a fixed boundary defined by the XR hardware.  An unbounded experience is one in which a user is able to freely move around their physical environment and travel significant distances.  A stationary experience is one which does not require the user to move around in space, and includes "seated" or "standing" experiences.  Examples of each of these types of experiences can be found in the detailed sections below.
+There are three types of reference spaces: `bounded`, `unbounded`, and `stationary`.  A bounded experience is one in which the user will move around their physical environment to fully interact, but will not need to travel beyond a fixed boundary defined by the XR hardware.  An unbounded experience is one in which a user is able to freely move around their physical environment and travel significant distances.  A stationary experience is one which does not require the user to move around in space, and includes "seated" or "standing" experiences.  Examples of each of these types of experiences can be found in the detailed sections below.
 
-It is worth noting that not all experiences will work on all XR hardware and not all XR hardware will support all experiences (see Appendix A: XRFrameOfReference Availability).  For example, it is not possible to build a experience which requires the user to walk around on a device like a GearVR.  In the spirit of [progressive enhancement](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement), it is strongly recommended that developers select the least capable `XRFrameOfReference` that suffices for the experience they are building.  Requesting a more capable frame of reference will artificially restrict the set of XR devices their experience will otherwise be viewable from.
+It is worth noting that not all experiences will work on all XR hardware and not all XR hardware will support all experiences (see [Appendix A: XRReferenceSpace Availability](#xrreferencespace-availability)).  For example, it is not possible to build a experience which requires the user to walk around on a device like a GearVR.  In the spirit of [progressive enhancement](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement), it is strongly recommended that developers select the least capable `XRReferenceSpace` that suffices for the experience they are building.  Requesting a more capable reference space will artificially restrict the set of XR devices their experience will otherwise be viewable from.
 
-### Bounded Frame of Reference
+### Bounded Reference Space
 A _bounded_ experience is one in which a user moves around their physical environment to fully interact, but will not need to travel beyond a pre-established boundary.  A _bounded_ experience is similar to a _unbounded_ experience in that both rely on XR hardware capable of tracking a users' locomotion.  However, _bounded_ experiences are explicitly focused on nearby content which allows them to target XR hardware that requires a pre-configured play area as well as XR hardware able to track location freely.
 
 Some example use cases: 
@@ -24,13 +24,13 @@ The origin of this type will be initialized at a position on the floor for which
 
 ```js
 let xrSession = null;
-let xrFrameOfReference = null;
+let xrReferenceSpace = null;
 
 function onSessionStarted(session) {
   xrSession = session;
-  xrSession.requestFrameOfReference({ type:'bounded' })
-  .then((frameOfReference) => {
-    xrFrameOfReference = frameOfReference;
+  xrSession.requestReferenceSpace({ type:'bounded' })
+  .then((referenceSpace) => {
+    xrReferenceSpace = referenceSpace;
   })
   .then(setupWebGLLayer)
   .then(() => {
@@ -39,7 +39,7 @@ function onSessionStarted(session) {
 }
 ```
 
-The `XRBoundedFrameOfReference` also reports geometry within which the application should try to ensure that all content the user needs to interact with can be reached. This polygonal boundary represents a loop of points at the edges of the safe space. The points are given in a clockwise order as viewed from above, looking towards the negative end of the Y axis. The shape it describes is not guaranteed to be convex. The values reported are relative to the frame of reference origin, and must have a `y` value of `0` and a `w` value of `1`.
+The `XRBoundedReferenceSpace` also reports geometry within which the application should try to ensure that all content the user needs to interact with can be reached. This polygonal boundary represents a loop of points at the edges of the safe space. The points are given in a clockwise order as viewed from above, looking towards the negative end of the Y axis. The shape it describes is not guaranteed to be convex. The values reported are relative to the reference space origin, and must have a `y` value of `0` and a `w` value of `1`.
 
 ```js
 // Demonstrated here using a fictional 3D library to simplify the example code.
@@ -47,17 +47,17 @@ function createBoundsMesh() {
   boundsMesh.clear();
   
   // Visualize the bounds geometry as 2 meter high quads
-  let pointCount = xrFrameOfReference.boundsGeometry.length;
+  let pointCount = xrReferenceSpace.boundsGeometry.length;
   for (let i = 0; i < pointCount - 1; ++i) {
-    let pointA = xrFrameOfReference.boundsGeometry[i];
-    let pointB = xrFrameOfReference.boundsGeometry[i+1];
+    let pointA = xrReferenceSpace.boundsGeometry[i];
+    let pointB = xrReferenceSpace.boundsGeometry[i+1];
     boundsMesh.addQuad(
         pointA.x, 0, pointA.z, // Quad Corner 1
         pointB.x, 2.0, pointB.z) // Quad Corner 2
   }
   // Close the loop
-  let pointA = xrFrameOfReference.boundsGeometry[pointCount-1];
-  let pointB = xrFrameOfReference.boundsGeometry[0];
+  let pointA = xrReferenceSpace.boundsGeometry[pointCount-1];
+  let pointB = xrReferenceSpace.boundsGeometry[0];
   boundsMesh.addQuad(
         pointA.x, 0, pointA.z, // Quad Corner 1
         pointB.x, 2.0, pointB.z) // Quad Corner 2
@@ -65,8 +65,8 @@ function createBoundsMesh() {
 }
 ```
 
-### Unbounded Frame of Reference
-A _unbounded_ experience is one in which the user is able to freely move around their physical environment. These experiences explicitly require that the user be unbounded in their ability to walk around, and the unbounded frame of reference will adjust its origin as needed to maintain optimal stability for the user, even if the user walks many meters from the origin. In doing so, the origin may drift from its original physical location. The origin will be initialized at a position near the user's head at the time of creation. The exact `x`, `y`, `z`, and orientation values will be initialized based on the conventions of the underlying platform for unbounded experiences.
+### Unbounded Reference Space
+A _unbounded_ experience is one in which the user is able to freely move around their physical environment. These experiences explicitly require that the user be unbounded in their ability to walk around, and the unbounded reference space will adjust its origin as needed to maintain optimal stability for the user, even if the user walks many meters from the origin. In doing so, the origin may drift from its original physical location. The origin will be initialized at a position near the user's head at the time of creation. The exact `x`, `y`, `z`, and orientation values will be initialized based on the conventions of the underlying platform for unbounded experiences.
 
 Some example use cases: 
 * Campus tour
@@ -74,13 +74,13 @@ Some example use cases:
 
 ```js
 let xrSession = null;
-let xrFrameOfReference = null;
+let xrReferenceSpace = null;
 
 function onSessionStarted(session) {
   xrSession = session;
-  xrSession.requestFrameOfReference({ type:'unbounded' })
-  .then((frameOfReference) => {
-    xrFrameOfReference = frameOfReference;
+  xrSession.requestReferenceSpace({ type:'unbounded' })
+  .then((referenceSpace) => {
+    xrReferenceSpace = referenceSpace;
   })
   .then(setupWebGLLayer)
   .then(() => {
@@ -89,15 +89,15 @@ function onSessionStarted(session) {
 }
 ```
 
-There is no mechanism for getting a floor-relative _unbounded_ frame of reference. This is because the user may move through a variety of elevations (via stairs, hills, etc), making identification of a single floor plane impossible.
+There is no mechanism for getting a floor-relative _unbounded_ reference space. This is because the user may move through a variety of elevations (via stairs, hills, etc), making identification of a single floor plane impossible.
 
-> **An aside regarding XRCoordinateSystem**
+> **An aside regarding XRSpace**
 >
 > When building an _unbounded_ experience, developers will likely need to "lock" content to a specific physical location to prevent it from drifting as users travel beyond a few meters; this functionality is known as _anchors_.  In addition to _anchors_, today's XR platforms offer other environment-related features such as _spatial meshes_, _point clouds_, _markers_, and more. While none of these features are yet part of the WebXR Device API, there are proposed designs under active development.
 >
-> The common property of these additional features and `XRFrameOfReference`, is that they all act as _spatial roots_ that are independently tracked by the underlying tracking systems. The concept of a _spatial roots_ is represented in the WebXR Device API as an `XRCoordinateSystem`.  Each instance of an `XRCoordinateSystem` does not have a fixed relationship with any other.  Instead, on a frame-by-frame basis, the tracking systems must attempt to locate them and compute their relative locations.  
+> The common property of these additional features and `XRReferenceSpace`, is that they all act as _spatial roots_ that are independently tracked by the underlying tracking systems. The concept of a _spatial roots_ is represented in the WebXR Device API as an `XRSpace`.  Each instance of an `XRSpace` does not have a fixed relationship with any other.  Instead, on a frame-by-frame basis, the tracking systems must attempt to locate them and compute their relative locations.  
 
-### Stationary Frame of Reference
+### Stationary Reference Space
 A _stationary_ experience is one which does not require the user to move around in space.  This includes several categories of experiences that developers are commonly building today.  "Standing" experiences can be created by passing the `floor-level` subtype.  "Seated" experiences can be created by passing the `eye-level` subtype.  Orientation-only experiences such as 360 photo/video viewers can be created by passing the `position-disabled` subtype.
 
 It is important to note that `XRViewerPose` objects retrieved using the `floor-level` and `eye-level` subtypes may include position information as well as rotation information.  For example, hardware which does not support 6DOF tracking (ex: GearVR) may still use neck-modeling to improve user comfort. Similarly, a user may lean side-to-side on a device with 6DOF tracking (ex: HTC Vive).  It is important for user comfort that developers do not attempt to remove position data from these matrices and instead use the `position-disabled` subtype.  The result is that `floor-level` and `eye-level` experiences should be resilient to position changes despite not being dependent on receiving them.  
@@ -112,13 +112,13 @@ Some example use cases:
 
 ```js
 let xrSession = null;
-let xrFrameOfReference = null;
+let xrReferenceSpace = null;
 
 function onSessionStarted(session) {
   xrSession = session;
-  xrSession.requestFrameOfReference({ type:'stationary', subtype:'floor-level' })
-  .then((frameOfReference) => {
-    xrFrameOfReference = frameOfReference;
+  xrSession.requestReferenceSpace({ type:'stationary', subtype:'floor-level' })
+  .then((referenceSpace) => {
+    xrReferenceSpace = referenceSpace;
   })
   .then(setupWebGLLayer)
   .then(() => {
@@ -138,13 +138,13 @@ Some example use cases:
 
 ```js
 let xrSession = null;
-let xrFrameOfReference = null;
+let xrReferenceSpace = null;
 
 function onSessionStarted(session) {
   xrSession = session;
-  xrSession.requestFrameOfReference({ type:'stationary' , subtype:'eye-level' })
-  .then((frameOfReference) => {
-    xrFrameOfReference = frameOfReference;
+  xrSession.requestReferenceSpace({ type:'stationary' , subtype:'eye-level' })
+  .then((referenceSpace) => {
+    xrReferenceSpace = referenceSpace;
   })
   .then(setupWebGLLayer)
   .then(() => {
@@ -162,13 +162,13 @@ Some example use cases:
 
 ```js
 let xrSession = null;
-let xrFrameOfReference = null;
+let xrReferenceSpace = null;
 
 function onSessionStarted(session) {
   xrSession = session;
-  xrSession.requestFrameOfReference({ type:'stationary', subtype:'position-disabled' })
-  .then((frameOfReference) => {
-    xrFrameOfReference = frameOfReference;
+  xrSession.requestReferenceSpace({ type:'stationary', subtype:'position-disabled' })
+  .then((referenceSpace) => {
+    xrReferenceSpace = referenceSpace;
   })
   .then(setupWebGLLayer)
   .then(() => {
@@ -180,28 +180,28 @@ function onSessionStarted(session) {
 ## Practical Usage Guidelines
 
 ### Inline Sessions
-Inline sessions, by definition, do not require a user gesture or user permission to create, and as a result there must be strong limitations on the pose data that can be reported for privacy and security reasons.  Requests for an `XRBoundedFrameOfReference` or an `XRUnboundedFrameOfReference` will always be rejected on inline sessions.  Requests for `XRStationaryFrameOfReference` may succeed, but may also be rejected if the UA is unable provide any tracking information such as for an inline session on a desktop PC or a 2D browser window in a headset.
+Inline sessions, by definition, do not require a user gesture or user permission to create, and as a result there must be strong limitations on the pose data that can be reported for privacy and security reasons.  Requests for an `XRBoundedReferenceSpace` or an `XRUnboundedReferenceSpace` will always be rejected on inline sessions.  Requests for `XRStationaryReferenceSpace` may succeed, but may also be rejected if the UA is unable provide any tracking information such as for an inline session on a desktop PC or a 2D browser window in a headset.
 
-Additionally, some inline experiences explicitly want tracking information disabled, such as a furniture viewer that will use pointer data to rotate the furniture.  Under both of these situations, there is no `XRFrameOfReference` needed.  Passing `null` as the `XRFrameOfReference` parameter to `getViewerPose()` or `getInputPose()` will return pose data whose values are based on the identity matrix.  Developers are then free to multiply in whatever transform they choose.
+Additionally, some inline experiences explicitly want tracking information disabled, such as a furniture viewer that will use pointer data to rotate the furniture.  Under both of these situations, there is no `XRReferenceSpace` needed.  Passing `null` as the `XRReferenceSpace` parameter to `getViewerPose()` or `getInputPose()` will return pose data whose values are based on the identity matrix.  Developers are then free to multiply in whatever transform they choose.
 
 ### Ensuring hardware compatibility
-Immersive sessions will always be able to provide a `XRStationaryFrameOfReference`, but may not support other `XRFrameOfReference` types due to hardware limitations.  Developers are strongly encouraged to follow the spirit of [progressive enhancement](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement) and provide a reasonable fallback behavior if their desired `XRBoundedFrameOfReference` or `XRUnboundedFrameOfReference` is unavailable.  In many cases it will be adequate for this fallback to behave similarly to an inline preview experience.
+Immersive sessions will always be able to provide a `XRStationaryReferenceSpace`, but may not support other `XRReferenceSpace` types due to hardware limitations.  Developers are strongly encouraged to follow the spirit of [progressive enhancement](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement) and provide a reasonable fallback behavior if their desired `XRBoundedReferenceSpace` or `XRUnboundedReferenceSpace` is unavailable.  In many cases it will be adequate for this fallback to behave similarly to an inline preview experience.
 
 ```js
 let xrSession = null;
-let xrFrameOfReference = null;
+let xrReferenceSpace = null;
 
 function onSessionStarted(session) {
   xrSession = session;
-  xrSession.requestFrameOfReference([
+  xrSession.requestReferenceSpace([
     { type:'unbounded' }, 
     { type:'stationary', subtype:'eye-level' }
   ])
-  .then((frameOfReference) => {
-    xrFrameOfReference = frameOfReference;
-    if (xrFrameOfReference instanceof XRUnboundedFrameOfReference) {
+  .then((referenceSpace) => {
+    xrReferenceSpace = referenceSpace;
+    if (xrReferenceSpace instanceof XRUnboundedReferenceSpace) {
       // Set up unbounded experience
-    } else if (xrFrameOfReference instanceof XRStationaryFrameOfReference) {
+    } else if (xrReferenceSpace instanceof XRStationaryReferenceSpace) {
       // Build an appropriate fallback experience if needed; perhaps similar to the inline version
     }
   })
@@ -216,42 +216,42 @@ While many sites will be able to provide this fallback, for some sites this will
 
 ```js
 function beginImmersiveSession() {
-  xrDevice.requestSession({ immersive: true,  requiredFrameOfReferenceType:'unbounded' })
+  xrDevice.requestSession({ immersive: true,  requiredReferenceSpaceType:'unbounded' })
       .then(onSessionStarted)
       .catch(err => {
-        // Error will indicate required frame of reference type unavailable
+        // Error will indicate required reference space type unavailable
       });
 }
 ```
 
 ### Floor Alignment
-Some XR hardware with inside-out tracking has users establish "known spaces" that can be used to easily provide `XRBoundedFrameOfReference` and the `floor-level` subtype of `XRStationaryFrameOfReference`.  On inside-out XR hardware which does not intrinsically provide these known spaces, the User Agent must still provide `XRStationaryFrameOfReference` of subtype `floor-level`.  It may do so by estimating a floor level, but may not present any UI at the time the frame of reference is requested.  
+Some XR hardware with inside-out tracking has users establish "known spaces" that can be used to easily provide `XRBoundedReferenceSpace` and the `floor-level` subtype of `XRStationaryReferenceSpace`.  On inside-out XR hardware which does not intrinsically provide these known spaces, the User Agent must still provide `XRStationaryReferenceSpace` of subtype `floor-level`.  It may do so by estimating a floor level, but may not present any UI at the time the reference space is requested.  
 
-Additionally, XR hardware with orientation-only tracking may also provide an emulated value for the floor offset of an `XRStationaryFrameOfReference` with the `floor-level` subtype.  On these devices, it is recommended that the User Agent or underlying platform provide a setting for users to customize this value.
+Additionally, XR hardware with orientation-only tracking may also provide an emulated value for the floor offset of an `XRStationaryReferenceSpace` with the `floor-level` subtype.  On these devices, it is recommended that the User Agent or underlying platform provide a setting for users to customize this value.
 
-### Relating between XRFrameOfReferences
-There are several circumstances in which developers may choose to relate content in different frames of reference.
+### Relating between XRReferenceSpaces
+There are several circumstances in which developers may choose to relate content in different reference spaces.
 
 #### Inline to Immersive
-It is expected that developers will often choose to preview `immersive` experiences with a similar experience `inline`.  In this situation, users often expect to see the scene from the same perspective when they make the transition from `inline` to `immersive`. To accomplish this, developers should grab the `poseMatrix` of the last `XRViewerPose` retrieved using the `inline` session's `XRFrameOfReference` and apply this same transform content to be displayed in the `immersive` session's `XRFrameOfReference`.  The same logic applies in the reverse when exiting `immersive`.
+It is expected that developers will often choose to preview `immersive` experiences with a similar experience `inline`.  In this situation, users often expect to see the scene from the same perspective when they make the transition from `inline` to `immersive`. To accomplish this, developers should grab the `poseMatrix` of the last `XRViewerPose` retrieved using the `inline` session's `XRReferenceSpace` and apply this same transform content to be displayed in the `immersive` session's `XRReferenceSpace`.  The same logic applies in the reverse when exiting `immersive`.
 
 #### Unbounded to Bounded 
-When building an experience that is predominantly based on an `XRUnboundedFrameOfReference`, developers may occasionally choose to switch to an `XRBoundedFrameOfReference`.  For example, a whole-home renovation experience might choose to switch to a bounded frame of reference for reviewing a furniture selection library.  If necessary to continue displaying content belonging to the previous frame of reference, developers may use the `coordinateSystem.getTransformTo()` method to re-parent nearby virtual content to the new frame of reference.
+When building an experience that is predominantly based on an `XRUnboundedReferenceSpace`, developers may occasionally choose to switch to an `XRBoundedReferenceSpace`.  For example, a whole-home renovation experience might choose to switch to a bounded reference space for reviewing a furniture selection library.  If necessary to continue displaying content belonging to the previous reference space, developers may use the `getTransformTo()` method to re-parent nearby virtual content to the new reference space.
 
 ### Reset Event
-The `XRFrameOfReference` type has an event, `onreset`, that is fired when a discontinuity of the frame of reference's origin occurs.  This discontinuity may be caused for different reasons for each type, but the result is essentially the same, the perception of the user's location will have changed.  In response, pages may wish to reposition virtual elements in the scene or clear any additional transforms, such as teleportation transforms, that may no longer be needed.  The `onreset` event will fire prior to any poses being delivered with the new origin/direction, and all poses queried following the event must be relative to the reset origin/direction. 
+The `XRReferenceSpace` type has an event, `onreset`, that is fired when a discontinuity of the reference space's origin occurs.  This discontinuity may be caused for different reasons for each type, but the result is essentially the same, the perception of the user's location will have changed.  In response, pages may wish to reposition virtual elements in the scene or clear any additional transforms, such as teleportation transforms, that may no longer be needed.  The `onreset` event will fire prior to any poses being delivered with the new origin/direction, and all poses queried following the event must be relative to the reset origin/direction. 
 
 ```js
-xrFrameOfReference.addEventListener('reset', xrFrameOfReferenceEvent => {
+xrReferenceSpace.addEventListener('reset', xrReferenceSpaceEvent => {
   // Check for the transformation between the previous origin and the current origin
   // This will not always be available, but if it is, developers may choose to use it
-  let transformMatrix = xrFrameOfReferenceEvent.transformMatrix;
+  let transformMatrix = xrReferenceSpaceEvent.transformMatrix;
 
   // For an app that allows artificial Yaw rotation, this would be a perfect
   // time to reset that.
   resetYawTransform(transformMatrix);
 
-  // For an app using the XRBoundedFrameOfReference, this would be a perfect time to
+  // For an app using the XRBoundedReferenceSpace, this would be a perfect time to
   // re-layout content intended to be reachable within the bounds
   createBoundsMesh(transformMatrix);
 });
@@ -261,9 +261,9 @@ Example reasons `onreset` may fire:
 * Some XR systems have a mechanism for allowing the user to reset which direction is "forward" or re-center the scene's origin at their current location.
 * When a user steps outside the bounds of a "known" playspace and enters a different "known" playspace
 * An inside-out based tracking system is temporarily unable to locate the user (ex: due to poor lighting conditions) and is unable to relate the new map fragment to the previous map fragment when it recovers
-* When the user has travelled far enough from the origin of an `XRUnboundedFrameOfReference` that floating point error would become problematic
+* When the user has travelled far enough from the origin of an `XRUnboundedReferenceSpace` that floating point error would become problematic
 
-The `onreset` event will **NOT** fire as an `XRUnboundedFrameOfReference` makes small changes to its origin as part of maintaining coordinate system stability near the user; these are considered minor corrections rather than a discontinuity in the origin.
+The `onreset` event will **NOT** fire as an `XRUnboundedReferenceSpace` makes small changes to its origin as part of maintaining space stability near the user; these are considered minor corrections rather than a discontinuity in the origin.
 
 ## Appendix A : Miscellaneous
 
@@ -278,34 +278,34 @@ In the context of XR, the term _tracking system_ refers to the technology by whi
 
 ### Decision flow chart
 
-How to pick a frame of reference:
+How to pick a reference space:
 ![Flow chart](frame-of-reference-flow-chart.jpg)
 
-### Frame of Reference Examples
+### Reference Space Examples
 
 | Type                           | Subtype             | Examples                                      |
 | -------------------------------| ------------------- | --------------------------------------------- |
-| `XRStationaryFrameOfReference` | `position-disabled` | - 360 photo/video viewer |
-| `XRStationaryFrameOfReference` | `eye-level`         | - Immersive 2D video viewer<br>- Racing simulator<br>- Solar system explorer |
-| `XRStationaryFrameOfReference` | `floor-level`       | - VR chat "room"<br>- Action game where you duck and dodge in place<br>- Fallback for Bounded experience that relies on teleportation instead |
-| `XRBoundedFrameOfReference`    |                     | - VR painting/sculpting tool<br>- Training simulators<br>- Dance games<br>- Previewing of 3D objects in the real world |
-| `XRUnboundedFrameOfReference`  |                     | - Campus tour<br>- Renovation preview |
+| `XRStationaryReferenceSpace` | `position-disabled` | - 360 photo/video viewer |
+| `XRStationaryReferenceSpace` | `eye-level`         | - Immersive 2D video viewer<br>- Racing simulator<br>- Solar system explorer |
+| `XRStationaryReferenceSpace` | `floor-level`       | - VR chat "room"<br>- Action game where you duck and dodge in place<br>- Fallback for Bounded experience that relies on teleportation instead |
+| `XRBoundedReferenceSpace`    |                     | - VR painting/sculpting tool<br>- Training simulators<br>- Dance games<br>- Previewing of 3D objects in the real world |
+| `XRUnboundedReferenceSpace`  |                     | - Campus tour<br>- Renovation preview |
 
-### XRFrameOfReference Availability
+### XRReferenceSpace Availability
 
-**Guaranteed** The UA will always be able to provide this frame of reference 
+**Guaranteed** The UA will always be able to provide this reference space 
 
-**Hardware-dependent** The UA will only be able to supply this frame of reference if running on XR hardware that supports it
+**Hardware-dependent** The UA will only be able to supply this reference space if running on XR hardware that supports it
 
-**Rejected** The UA will never provide this frame of reference
+**Rejected** The UA will never provide this reference space
 
 | Type                           | Subtype             | Inline             | Immersive |
 | -------------------------------| ------------------- | ------------------ | ---------- |
-| `XRStationaryFrameOfReference` | `position-disabled` | Hardware-dependent | Guaranteed |
-| `XRStationaryFrameOfReference` | `eye-level`         | Hardware-dependent | Guaranteed |
-| `XRStationaryFrameOfReference` | `floor-level`       | Hardware-dependent | Guaranteed |
-| `XRBoundedFrameOfReference`    |                     | Rejected           | Hardware-dependent |
-| `XRUnboundedFrameOfReference`  |                     | Rejected           | Hardware-dependent |
+| `XRStationaryReferenceSpace` | `position-disabled` | Hardware-dependent | Guaranteed |
+| `XRStationaryReferenceSpace` | `eye-level`         | Hardware-dependent | Guaranteed |
+| `XRStationaryReferenceSpace` | `floor-level`       | Hardware-dependent | Guaranteed |
+| `XRBoundedReferenceSpace`    |                     | Rejected           | Hardware-dependent |
+| `XRUnboundedReferenceSpace`  |                     | Rejected           | Hardware-dependent |
 
 ## Appendix B: Proposed partial IDL
 This is a partial IDL and is considered additive to the core IDL found in the main [explainer](explainer.md).
@@ -316,11 +316,11 @@ This is a partial IDL and is considered additive to the core IDL found in the ma
 //
 
 partial dictionary XRSessionCreationOptions {
-  XRFrameOfReferenceType requiredFrameOfReferenceType;
+  XRReferenceSpaceType requiredReferenceSpaceType;
 };
 
 partial interface XRSession {
-  Promise<XRFrameOfReference> requestFrameOfReference(Array<XRFrameOfReferenceOptions> preferredOptions);
+  Promise<XRReferenceSpace> requestReferenceSpace(Array<XRReferenceSpaceOptions> preferredOptions);
 };
 
 //
@@ -329,10 +329,10 @@ partial interface XRSession {
 
 partial interface XRFrame {
   // Also listed in the main explainer.md
-  XRViewerPose? getViewerPose(optional XRFrameOfReference frameOfReference);
+  XRViewerPose? getViewerPose(optional XRReferenceSpace referenceSpace);
 
   // Also listed in input-explainer.md
-  XRInputPose? getInputPose(XRInputSource inputSource, optional XRFrameOfReference frameOfReference);
+  XRInputPose? getInputPose(XRInputSource inputSource, optional XRReferenceSpace referenceSpace);
 };
 
 [SecureContext, Exposed=Window]
@@ -343,67 +343,65 @@ interface XRInputPose {
 };
 
 //
-// Coordinate System
+// Space
 //
 
-[SecureContext, Exposed=Window] interface XRCoordinateSystem {
-  Float32Array? getTransformTo(XRCoordinateSystem other);
+[SecureContext, Exposed=Window] interface XRSpace : EventTarget {
+  Float32Array? getTransformTo(XRSpace other);
 };
 
 //
-// Frame of Reference
+// Reference Space
 //
 
-enum XRFrameOfReferenceType {
+enum XRReferenceSpaceType {
   "stationary",
   "bounded",
   "unbounded"
 };
 
-dictionary XRFrameOfReferenceOptions {
-  required XRFrameOfReferenceType type;
+dictionary XRReferenceSpaceOptions {
+  required XRReferenceSpaceType type;
 };
 
-[SecureContext, Exposed=Window] interface XRFrameOfReference : EventTarget {
-  readonly attribute XRCoordinateSystem coordinateSystem;
-  
+[SecureContext, Exposed=Window] interface XRReferenceSpace : XRSpace {  
   attribute EventHandler onreset;
 };
 
 //
-// Stationary Frame of Reference
+// Stationary Reference Space
 //
 
-enum XRStationaryFrameOfReferenceSubtype {
+enum XRStationaryReferenceSpaceSubtype {
   "eye-level",
   "floor-level",
   "position-disabled"
 }
 
-dictionary XRStationaryFrameOfReferenceOptions : XRFrameOfReferenceOptions {
-  required XRStationaryFrameOfReferenceSubtype subtype;
+dictionary XRStationaryReferenceSpaceOptions : XRReferenceSpaceOptions {
+  required XRStationaryReferenceSpaceSubtype subtype;
 };
 
 [SecureContext, Exposed=Window]
-interface XRStationaryFrameOfReference : XRFrameOfReference {
-  readonly attribute XRStationaryFrameOfReferenceSubtype subtype;
+interface XRStationaryReferenceSpace : XRReferenceSpace {
+  readonly attribute XRStationaryReferenceSpaceSubtype subtype;
 };
 
 //
-// Bounded Frame of Reference
+// Bounded Reference Space
 //
 
 [SecureContext, Exposed=Window]
-interface XRBoundedFrameOfReference : XRFrameOfReference {
+interface XRBoundedReferenceSpace : XRReferenceSpace {
   readonly attribute FrozenArray<DOMPointReadOnly> boundsGeometry;
 };
 
 //
-// Unbounded Frame of Reference
+// Unbounded Reference Space
 //
 
 [SecureContext, Exposed=Window] 
-interface XRUnboundedFrameOfReference : XRFrameOfReference {
+interface XRUnboundedReferenceSpace : XRReferenceSpace {
 };
 
 //
@@ -411,14 +409,14 @@ interface XRUnboundedFrameOfReference : XRFrameOfReference {
 //
 
 [SecureContext, Exposed=Window,
- Constructor(DOMString type, XRFrameOfReferenceEventInit eventInitDict)]
-interface XRFrameOfReferenceEvent : Event {
-  readonly attribute XRFrameOfReference frameOfReference;
+ Constructor(DOMString type, XRReferenceSpaceEventInit eventInitDict)]
+interface XRReferenceSpaceEvent : Event {
+  readonly attribute XRReferenceSpace referenceSpace;
   readonly attribute Float32Array? transformMatrix;
 };
 
-dictionary XRFrameOfReferenceEventInit : EventInit {
-  required XRFrameOfReference frameOfReference;
+dictionary XRReferenceSpaceEventInit : EventInit {
+  required XRReferenceSpace referenceSpace;
   Float32Array transformMatrix;
 };
 ```


### PR DESCRIPTION
Fixes #418. This is a pretty simple search-and-replace PR that just switches the explainers over to the new verbiage discussed in #418.