### PR TITLE
Introduce XRRigidTransform

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -622,6 +622,7 @@ interface XRRigidTransform {
   readonly attribute XREye eye;
   readonly attribute Float32Array projectionMatrix;
   readonly attribute Float32Array viewMatrix;
+  readonly attribute XRRigidTransform transform;
 };
 
 [SecureContext, Exposed=Window] interface XRViewerPose {

--- a/explainer.md
+++ b/explainer.md
@@ -209,7 +209,7 @@ The `XRWebGLLayer`s framebuffer is created by the UA and behaves similarly to a 
 
 Once drawn to, the XR device will continue displaying the contents of the `XRWebGLLayer` framebuffer, potentially reprojected to match head motion, regardless of whether or not the page continues processing new frames. Potentially future spec iterations could enable additional types of layers, such as video layers, that could automatically be synchronized to the device's refresh rate.
 
-To get view matrices or the `poseMatrix` for each `XRFrame`, developers must call `getViewerPose()` and provide an `XRReferenceSpace` in which these matrices should be returned. Due to the nature of XR tracking systems, this function is not guaranteed to return a value and developers will need to respond appropriately.  For more information about what situations will cause `getViewerPose()` to fail and recommended practices for handling the situation, refer to the [Spatial Tracking Explainer](spatial-tracking-explainer.md).
+To get view matrices or the viewer's `transform` for each `XRFrame`, developers must call `getViewerPose()` and provide an `XRReferenceSpace` in which these matrices should be returned. Due to the nature of XR tracking systems, this function is not guaranteed to return a value and developers will need to respond appropriately.  For more information about what situations will cause `getViewerPose()` to fail and recommended practices for handling the situation, refer to the [Spatial Tracking Explainer](spatial-tracking-explainer.md).
 
 ```js
 function onDrawFrame(timestamp, xrFrame) {
@@ -240,7 +240,7 @@ function drawScene(view) {
   let viewMatrix = null;
   let projectionMatrix = null;
   if (view) {
-    viewMatrix = pose.viewMatrix;
+    viewMatrix = view.viewMatrix;
     projectionMatrix = view.projectionMatrix;
   } else {
     viewMatrix = defaultViewMatrix;
@@ -609,6 +609,15 @@ enum XREye {
   "right"
 };
 
+[SecureContext, Exposed=Window,
+ Constructor(optional DOMPointInit translation, optional DOMPointInit orientation)]
+interface XRRigidTransform {
+  readonly attribute DOMPointReadOnly translation;
+  readonly attribute DOMPointReadOnly orientation;
+
+  readonly attribute Float32Array matrix;
+};
+
 [SecureContext, Exposed=Window] interface XRView {
   readonly attribute XREye eye;
   readonly attribute Float32Array projectionMatrix;
@@ -616,7 +625,7 @@ enum XREye {
 };
 
 [SecureContext, Exposed=Window] interface XRViewerPose {
-  readonly attribute Float32Array poseMatrix;
+  readonly attribute XRRigidTransform transform;
   readonly attribute FrozenArray<XRView> views;
 };
 

--- a/explainer.md
+++ b/explainer.md
@@ -209,7 +209,11 @@ The `XRWebGLLayer`s framebuffer is created by the UA and behaves similarly to a 
 
 Once drawn to, the XR device will continue displaying the contents of the `XRWebGLLayer` framebuffer, potentially reprojected to match head motion, regardless of whether or not the page continues processing new frames. Potentially future spec iterations could enable additional types of layers, such as video layers, that could automatically be synchronized to the device's refresh rate.
 
-To get view matrices or the viewer's `transform` for each `XRFrame`, developers must call `getViewerPose()` and provide an `XRReferenceSpace` in which these matrices should be returned. Due to the nature of XR tracking systems, this function is not guaranteed to return a value and developers will need to respond appropriately.  For more information about what situations will cause `getViewerPose()` to fail and recommended practices for handling the situation, refer to the [Spatial Tracking Explainer](spatial-tracking-explainer.md).
+### Viewer tracking
+
+Each `XRFrame` the scene will be drawn from the perspective of a "viewer", which is the user or device viewing the scene, described by an `XRViewerPose`. Developers retrieve the current `XRViewerPose` by calling `getViewerPose()` on the `XRFrame` and providing an `XRReferenceSpace` for the pose to be returned in. Due to the nature of XR tracking systems, this function is not guaranteed to return a value and developers will need to respond appropriately.  For more information about what situations will cause `getViewerPose()` to fail and recommended practices for handling the situation, refer to the [Spatial Tracking Explainer](spatial-tracking-explainer.md).
+
+The `XRViewerPose` contains a `views` attribute, which is an array of `XRView`s. Each `XRView` has a `viewMatrix` and a `projectionMatrix` that should be used when rendering with WebGL. The `XRView` is also passed to an `XRWebGLLayer`'s `getViewport()` method to determine what the WebGL viewport should be set to when rendering. This ensures that the appropriate perspectives of scene are rendered to the correct portion on the `XRWebGLLayer`'s `framebuffer` in order to display correctly on the XR hardware.
 
 ```js
 function onDrawFrame(timestamp, xrFrame) {
@@ -252,6 +256,10 @@ function drawScene(view) {
   // Draw Scene
 }
 ```
+
+The `XRViewerPose` also contains a `transform`, which is an `XRRigidTransform` describing the position and orientation of the viewer as a whole relative to the `XRReferenceSpace` origin. This is primarily useful for rendering a visual representation of the viewer for spectator views or multi-user environments. Each `XRView` has a `transform` as well that can be used in lieu of the `viewMatrix` to position virtual cameras in the scene if the rendering library being used prefers.
+
+An `XRRigidTransform` contains a `position` vector and `orientation` quaternion. When interpreting an `XRRigidTransform` the `orientation` is applied prior to the `position`. This means that, for example, a transform that indicates a quarter rotation to the right and a 1 meter translation along -Z would place a transformed object at `[0, 0, -1]` facing to the right. `XRRigidTransform`s also have a `matrix` attribute that reports the same transform as a 4x4 matrix when needed.
 
 ### Handling suspended sessions
 
@@ -610,11 +618,10 @@ enum XREye {
 };
 
 [SecureContext, Exposed=Window,
- Constructor(optional DOMPointInit translation, optional DOMPointInit orientation)]
+ Constructor(optional DOMPointInit position, optional DOMPointInit orientation)]
 interface XRRigidTransform {
-  readonly attribute DOMPointReadOnly translation;
+  readonly attribute DOMPointReadOnly position;
   readonly attribute DOMPointReadOnly orientation;
-
   readonly attribute Float32Array matrix;
 };
 

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -27,15 +27,15 @@ The properties of an XRInputSource object are immutable. If a device can be mani
 
 Each input source can query a `XRInputPose` using the `getInputPose()` function of any `XRFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRReferenceSpace` the pose values should be given in, just like `getViewerPose()`. `getInputPose()` may return `null` in cases where tracking has been lost (similar to `getViewerPose()`), or the given `XRInputSource` instance is no longer connected or available.
 
-The `grip` is an `XRRigidTransform` into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
+The `gripTransform` is an `XRRigidTransform` into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
 
-If the input source has only 3DOF, the grip transform may represent only a translation or rotation based on tracking capability. An example of this case is for physical hands on some AR devices which only have a tracked position. The `grip` will be `null` if the input source isn't trackable. 
+If the input source has only 3DOF, the `gripTransform` may represent only a translation or rotation based on tracking capability. An example of this case is for physical hands on some AR devices which only have a tracked position. The `gripTransform` will be `null` if the input source isn't trackable. 
 
 An input source will also provide its preferred pointing ray, given by the `XRInputPose`'s `targetRay`. The ray, which is an `XRRay` object, includes both an `origin` and `direction`, both given as `DOMPointReadOnly`s. The `origin` represents a 3D coordinate in space with a `w` component that must be 1, and the `direction` represents a normalized 3D directional vector with a `w` component that must be 0. A matrix can also be queried from the `XRRay` with the `matrix` attribute which represents the transform from a ray originating at `[0, 0, 0]` and extending down the negative Z axis to the ray described by the `XRRay`'s `origin` and `direction`. This is useful for positioning graphical representations of the ray.
 
 The `targetRay` will never be `null`. It's value will differ based on the type of input source that produces it, which is represented by the `targetRayMode` attribute:
 
-  * `'gaze'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a grip transform), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
+  * `'gaze'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a `gripTransform`), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
   * `'tracked-pointer'` indicates that the target ray originates from either a handheld device or other hand-tracking mechanism and represents that the user is using their hands or the held device for pointing. The exact orientation of the ray relative to a given device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance or a physical device, the target ray should most likely point in the same direction as the user's index finger if it was outstretched.
   * `'screen'` indicates that the input source was an interaction with a session's output context canvas element, such as a mouse click or touch event. Only applicable for inline sessions or an immersive AR session being displayed on a 2D screen. See [Screen Input](#screen_input) for more details.
 
@@ -173,7 +173,7 @@ function onSelect(event) {
 Most applications will want to visually represent the input sources somehow. The appropriate type of visualization to be used depends on the value of the `targetRayMode` attribute:
 
   * `'gaze'`: A cursor should be drawn at some distance down the target ray, ideally at the depth of the first surface it intersects with, so the user can identify what will be interacted with when a select event is fired. It's not appropriate to draw a controller or ray in this case, since they may obscure the user's vision or be difficult to visually converge on.
-  * `'tracked-pointer'`: If the `grip` is not `null` an application-appropriate controller model should be drawn using that transform. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
+  * `'tracked-pointer'`: If the `gripTransform` is not `null` an application-appropriate controller model should be drawn using that transform. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
   * `'screen'`: In all cases the point of origin of the target ray is obvious and no visualization is needed.
 
 ```js
@@ -183,10 +183,10 @@ Most applications will want to visually represent the input sources somehow. The
 function renderInputSource(session, inputSource, inputPose) {
   // FIXME: Using a fictional isDisplayOpaque() method to state that controller meshes should not be rendered
   // on transparent displays (AR).
-  if (isDisplayOpaque(session) && inputPose.grip) {
-    // Render a controller mesh if the using the grip as a transform.
+  if (isDisplayOpaque(session) && inputPose.gripTransform) {
+    // Render a controller mesh the using the gripTransform.
     let controllerMesh = getControllerMesh(inputSource);
-    renderer.drawMeshAtTransform(controllerMesh, inputPose.grip);
+    renderer.drawMeshAtTransform(controllerMesh, inputPose.gripTransform);
   }
 }
 
@@ -233,19 +233,19 @@ function onSelectStart(event) {
   
   let inputPose = event.frame.getInputPose(event.inputSource, xrReferenceSpace);
   // Ignore the event if this input source is not capable of tracking.
-  if (!inputPose || !inputPose.grip)
+  if (!inputPose || !inputPose.gripTransform)
     return;
 
   // Use the input source target ray to find a draggable object in the scene
   let ray = inputPose.targetRay;
   let hitResult = scene.hitTest(ray.origin, ray.direction);
   if (hitResult && hitResult.draggable) {
-    // Use the grip translation to drag the intersected object, rather than the target ray.
+    // Use the grip position to drag the intersected object, rather than the target ray.
     activeDragInteraction = {
       target: hitResult,
       targetStartPosition: hitResult.position,
       inputSource: event.inputSource,
-      inputSourceStartPosition: inputPose.grip.translation;
+      inputSourceStartPosition: inputPose.gripTransform.position;
     };
   }
 }
@@ -260,11 +260,10 @@ function onSelectEnd(event) {
 function onUpdateScene() {
   if (activeDragInteraction) {
     let inputPose = frame.getInputPose(activeDragInteraction.inputSource, xrReferenceSpace);
-    if (inputPose && inputPose.grip) {
+    if (inputPose && inputPose.gripTransform) {
       // Determine the vector from the start of the drag to the input source's current position
       // and position the draggable object accordingly
-      let inputSourcePosition = inputPose.grip.translation;
-      let deltaPosition = Vector3.subtract(inputSourcePosition, activeDragInteraction.inputSourceStartPosition);
+      let deltaPosition = Vector3.subtract(inputPose.gripTransform.position, activeDragInteraction.inputSourceStartPosition);
       let newPosition = Vector3.add(activeDragInteraction.targetStartPosition, deltaPosition);
       activeDragInteraction.target.setPosition(newPosition);
     }
@@ -272,7 +271,7 @@ function onUpdateScene() {
 }
 ```
 
-The above sample is optimized for dragging items in the scene around using input sources that have a `grip` transform. It would also be possible to add further script logic to use the target ray properties to position items in the world - this is left as an exercise for the reader.
+The above sample is optimized for dragging items in the scene around using input sources that have a `gripTransform`. It would also be possible to add further script logic to use the target ray properties to position items in the world - this is left as an exercise for the reader.
 
 ### Screen Input
 
@@ -342,7 +341,7 @@ interface XRInputSource {
 interface XRInputPose {
   readonly attribute boolean emulatedPosition;
   readonly attribute XRRay targetRay;
-  readonly attribute XRRigidTransform? grip;
+  readonly attribute XRRigidTransform? gripTransform;
 };
 
 //

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -5,7 +5,7 @@ This document is a subsection of the main WebXR Device API explainer document wh
 
 XR hardware provides a wide variety of input mechanisms, ranging from single state buttons to fully tracked controllers with multiple buttons, joysticks, triggers, or touchpads. While the intent is to eventually support the full range of available hardware, for the initial version of the WebXR Device API the focus is on enabling a more universal "point and click" style system that can be supported in some capacity by any known XR device and in inline mode.
 
-In this model every input source has a ray that indicates what is being pointed at, called the "Target Ray", and reports when the primary action for that device has been triggered, surfaced as a "select" event. When the select event is fired the XR application can use the target ray of the input source that generated the event to determine what the user was attempting to interact with and respond accordingly. Additionally, if the input source represents a tracked device a "Grip" matrix will also be provided to indicate where a mesh should be rendered to align with the physical device.
+In this model every input source has a ray that indicates what is being pointed at, called the "Target Ray", and reports when the primary action for that device has been triggered, surfaced as a "select" event. When the select event is fired the XR application can use the target ray of the input source that generated the event to determine what the user was attempting to interact with and respond accordingly. Additionally, if the input source represents a tracked device a "Grip" transform will also be provided to indicate where a mesh should be rendered to align with the physical device.
 
 ### Enumerating input sources
 
@@ -27,15 +27,15 @@ The properties of an XRInputSource object are immutable. If a device can be mani
 
 Each input source can query a `XRInputPose` using the `getInputPose()` function of any `XRFrame`. Getting the pose requires passing in the `XRInputSource` you want the pose for, as well as the `XRReferenceSpace` the pose values should be given in, just like `getViewerPose()`. `getInputPose()` may return `null` in cases where tracking has been lost (similar to `getViewerPose()`), or the given `XRInputSource` instance is no longer connected or available.
 
-The `gripMatrix` is a transform into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
+The `grip` is an `XRRigidTransform` into a space where if the user was holding a straight rod in their hand it would be aligned with the negative Z axis (forward) and the origin rests at their palm. This enables developers to properly render a virtual object held in the user's hand. For example, a sword would be positioned so that the blade points directly down the negative Z axis and the center of the handle is at the origin.
 
-If the input source has only 3DOF, the grip matrix may represent only a translation or rotation based on tracking capability. An example of this case is for physical hands on some AR devices which only have a tracked position. The `gripMatrix` will be `null` if the input source isn't trackable. 
+If the input source has only 3DOF, the grip transform may represent only a translation or rotation based on tracking capability. An example of this case is for physical hands on some AR devices which only have a tracked position. The `grip` will be `null` if the input source isn't trackable. 
 
-An input source will also provide its preferred pointing ray, given by the `XRInputPose`'s `targetRay`. The ray, which is an `XRRay` object, includes both an `origin` and `direction`, both given as `DOMPointReadOnly`s. The `origin` represents a 3D coordinate in space with a `w` component that must be 1, and the `direction` represents a normalized 3D directional vector with a `w` component that must be 0. The `XRRay` also defines a `transformMatrix` which represents the transform from a ray originating at `[0, 0, 0]` and extending down the negative Z axis to the ray described by the `XRRay`'s `origin` and `direction`. This is useful for positioning graphical representations of the ray.
+An input source will also provide its preferred pointing ray, given by the `XRInputPose`'s `targetRay`. The ray, which is an `XRRay` object, includes both an `origin` and `direction`, both given as `DOMPointReadOnly`s. The `origin` represents a 3D coordinate in space with a `w` component that must be 1, and the `direction` represents a normalized 3D directional vector with a `w` component that must be 0. A matrix can also be queried from the `XRRay` with the `matrix` attribute which represents the transform from a ray originating at `[0, 0, 0]` and extending down the negative Z axis to the ray described by the `XRRay`'s `origin` and `direction`. This is useful for positioning graphical representations of the ray.
 
 The `targetRay` will never be `null`. It's value will differ based on the type of input source that produces it, which is represented by the `targetRayMode` attribute:
 
-  * `'gaze'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a grip matrix), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
+  * `'gaze'` indicates the target ray will originate at the user's head and follow the direction they are looking (this is commonly referred to as a "gaze input" device). While it may be possible for these devices to be tracked (and have a grip transform), the head gaze is used for targeting. Example devices: 0DOF clicker, regular gamepad, voice command, tracked hands.
   * `'tracked-pointer'` indicates that the target ray originates from either a handheld device or other hand-tracking mechanism and represents that the user is using their hands or the held device for pointing. The exact orientation of the ray relative to a given device should follow platform-specific guidelines if there are any. In the absence of platform-specific guidance or a physical device, the target ray should most likely point in the same direction as the user's index finger if it was outstretched.
   * `'screen'` indicates that the input source was an interaction with a session's output context canvas element, such as a mouse click or touch event. Only applicable for inline sessions or an immersive AR session being displayed on a 2D screen. See [Screen Input](#screen_input) for more details.
 
@@ -161,9 +161,7 @@ function onSelect(event) {
 
   // Ray cast into scene with the viewer pose to determine if anything was hit.
   // Assumes the use of a fictionalized math and scene library.
-  let rayOrigin = getTranslation(viewerPose.poseMatrix);
-  let rayDirection = applyRotation(scene.forwardVector, viewerPose.poseMatrix);
-  let selectedObject = scene.getObjectIntersectingRay(rayOrigin, rayDirection);
+  let selectedObject = scene.getObjectIntersectingRay(new XRRay(viewerPose.transform));
   if (selectedObject) {
     selectedObject.onSelect();
   }
@@ -175,7 +173,7 @@ function onSelect(event) {
 Most applications will want to visually represent the input sources somehow. The appropriate type of visualization to be used depends on the value of the `targetRayMode` attribute:
 
   * `'gaze'`: A cursor should be drawn at some distance down the target ray, ideally at the depth of the first surface it intersects with, so the user can identify what will be interacted with when a select event is fired. It's not appropriate to draw a controller or ray in this case, since they may obscure the user's vision or be difficult to visually converge on.
-  * `'tracked-pointer'`: If the `gripMatrix` in not `null` an application-appropriate controller model should be drawn using that matrix as the transform. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
+  * `'tracked-pointer'`: If the `grip` is not `null` an application-appropriate controller model should be drawn using that transform. If appropriate for the experience, the a visualization of the target ray and a cursor as described in the `'gaze'` should also be drawn.
   * `'screen'`: In all cases the point of origin of the target ray is obvious and no visualization is needed.
 
 ```js
@@ -185,10 +183,10 @@ Most applications will want to visually represent the input sources somehow. The
 function renderInputSource(session, inputSource, inputPose) {
   // FIXME: Using a fictional isDisplayOpaque() method to state that controller meshes should not be rendered
   // on transparent displays (AR).
-  if (isDisplayOpaque(session) && inputPose.gripMatrix) {
-    // Render a controller mesh if the using the gripMatrix as a transform.
+  if (isDisplayOpaque(session) && inputPose.grip) {
+    // Render a controller mesh if the using the grip as a transform.
     let controllerMesh = getControllerMesh(inputSource);
-    renderer.drawMeshWithTransform(controllerMesh, inputPose.gripMatrix);
+    renderer.drawMeshAtTransform(controllerMesh, inputPose.grip);
   }
 }
 
@@ -235,19 +233,19 @@ function onSelectStart(event) {
   
   let inputPose = event.frame.getInputPose(event.inputSource, xrReferenceSpace);
   // Ignore the event if this input source is not capable of tracking.
-  if (!inputPose || !inputPose.gripMatrix)
+  if (!inputPose || !inputPose.grip)
     return;
 
   // Use the input source target ray to find a draggable object in the scene
   let ray = inputPose.targetRay;
   let hitResult = scene.hitTest(ray.origin, ray.direction);
   if (hitResult && hitResult.draggable) {
-    // Use the gripMatrix translation to drag the intersected object, rather than the target ray.
+    // Use the grip translation to drag the intersected object, rather than the target ray.
     activeDragInteraction = {
       target: hitResult,
       targetStartPosition: hitResult.position,
       inputSource: event.inputSource,
-      inputSourceStartPosition: getTranslation(inputPose.gripMatrix);
+      inputSourceStartPosition: inputPose.grip.translation;
     };
   }
 }
@@ -262,10 +260,10 @@ function onSelectEnd(event) {
 function onUpdateScene() {
   if (activeDragInteraction) {
     let inputPose = frame.getInputPose(activeDragInteraction.inputSource, xrReferenceSpace);
-    if (inputPose && inputPose.gripMatrix) {
+    if (inputPose && inputPose.grip) {
       // Determine the vector from the start of the drag to the input source's current position
       // and position the draggable object accordingly
-      let inputSourcePosition = getTranslation(inputPose.gripMatrix);
+      let inputSourcePosition = inputPose.grip.translation;
       let deltaPosition = Vector3.subtract(inputSourcePosition, activeDragInteraction.inputSourceStartPosition);
       let newPosition = Vector3.add(activeDragInteraction.targetStartPosition, deltaPosition);
       activeDragInteraction.target.setPosition(newPosition);
@@ -274,7 +272,7 @@ function onUpdateScene() {
 }
 ```
 
-The above sample is optimized for dragging items in the scene around using input sources that have a gripMatrix. It would also be possible to add further script logic to use the target ray properties to position items in the world - this is left as an exercise for the reader.
+The above sample is optimized for dragging items in the scene around using input sources that have a `grip` transform. It would also be possible to add further script logic to use the target ray properties to position items in the world - this is left as an exercise for the reader.
 
 ### Screen Input
 
@@ -313,11 +311,13 @@ partial interface XRFrame {
 // Input
 //
 
-[SecureContext, Exposed=Window]
+[SecureContext, Exposed=Window,
+ Constructor(optional DOMPointInit origin, optional DOMPointInit direction),
+ Constructor(XRRigidTransform transform)]
 interface XRRay {
   readonly attribute DOMPointReadOnly origin;
   readonly attribute DOMPointReadOnly direction;
-  readonly attribute Float32Array transformMatrix;
+  readonly attribute Float32Array matrix;
 };
 
 enum XRHandedness {
@@ -342,7 +342,7 @@ interface XRInputSource {
 interface XRInputPose {
   readonly attribute boolean emulatedPosition;
   readonly attribute XRRay targetRay;
-  readonly attribute Float32Array? gripMatrix;
+  readonly attribute XRRigidTransform? grip;
 };
 
 //

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -233,7 +233,7 @@ Additionally, XR hardware with orientation-only tracking may also provide an emu
 There are several circumstances in which developers may choose to relate content in different reference spaces.
 
 #### Inline to Immersive
-It is expected that developers will often choose to preview `immersive` experiences with a similar experience `inline`.  In this situation, users often expect to see the scene from the same perspective when they make the transition from `inline` to `immersive`. To accomplish this, developers should grab the `poseMatrix` of the last `XRViewerPose` retrieved using the `inline` session's `XRReferenceSpace` and apply this same transform content to be displayed in the `immersive` session's `XRReferenceSpace`.  The same logic applies in the reverse when exiting `immersive`.
+It is expected that developers will often choose to preview `immersive` experiences with a similar experience `inline`.  In this situation, users often expect to see the scene from the same perspective when they make the transition from `inline` to `immersive`. To accomplish this, developers should grab the `transform` of the last `XRViewerPose` retrieved using the `inline` session's `XRReferenceSpace` and apply this same transform to content to be displayed in the `immersive` session's `XRReferenceSpace`.  The same logic applies in the reverse when exiting `immersive`.
 
 #### Unbounded to Bounded 
 When building an experience that is predominantly based on an `XRUnboundedReferenceSpace`, developers may occasionally choose to switch to an `XRBoundedReferenceSpace`.  For example, a whole-home renovation experience might choose to switch to a bounded reference space for reviewing a furniture selection library.  If necessary to continue displaying content belonging to the previous reference space, developers may use the `getTransformTo()` method to re-parent nearby virtual content to the new reference space.
@@ -245,15 +245,15 @@ The `XRReferenceSpace` type has an event, `onreset`, that is fired when a discon
 xrReferenceSpace.addEventListener('reset', xrReferenceSpaceEvent => {
   // Check for the transformation between the previous origin and the current origin
   // This will not always be available, but if it is, developers may choose to use it
-  let transformMatrix = xrReferenceSpaceEvent.transformMatrix;
+  let transform = xrReferenceSpaceEvent.transform;
 
   // For an app that allows artificial Yaw rotation, this would be a perfect
   // time to reset that.
-  resetYawTransform(transformMatrix);
+  resetYawTransform(transform);
 
   // For an app using the XRBoundedReferenceSpace, this would be a perfect time to
   // re-layout content intended to be reachable within the bounds
-  createBoundsMesh(transformMatrix);
+  createBoundsMesh(transform);
 });
 ```
 
@@ -339,7 +339,7 @@ partial interface XRFrame {
 interface XRInputPose {
   readonly attribute boolean emulatedPosition;
   readonly attribute XRRay targetRay;
-  readonly attribute Float32Array? gripMatrix;
+  readonly attribute XRRigidTransform? grip;
 };
 
 //
@@ -347,7 +347,7 @@ interface XRInputPose {
 //
 
 [SecureContext, Exposed=Window] interface XRSpace : EventTarget {
-  Float32Array? getTransformTo(XRSpace other);
+  XRRigidTransform? getTransformTo(XRSpace other);
 };
 
 //
@@ -364,7 +364,7 @@ dictionary XRReferenceSpaceOptions {
   required XRReferenceSpaceType type;
 };
 
-[SecureContext, Exposed=Window] interface XRReferenceSpace : XRSpace {  
+[SecureContext, Exposed=Window] interface XRReferenceSpace : XRSpace {
   attribute EventHandler onreset;
 };
 
@@ -412,11 +412,11 @@ interface XRUnboundedReferenceSpace : XRReferenceSpace {
  Constructor(DOMString type, XRReferenceSpaceEventInit eventInitDict)]
 interface XRReferenceSpaceEvent : Event {
   readonly attribute XRReferenceSpace referenceSpace;
-  readonly attribute Float32Array? transformMatrix;
+  readonly attribute XRRigidTransform? transform;
 };
 
 dictionary XRReferenceSpaceEventInit : EventInit {
   required XRReferenceSpace referenceSpace;
-  Float32Array transformMatrix;
+  XRRigidTransform transform;
 };
 ```

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -339,7 +339,7 @@ partial interface XRFrame {
 interface XRInputPose {
   readonly attribute boolean emulatedPosition;
   readonly attribute XRRay targetRay;
-  readonly attribute XRRigidTransform? grip;
+  readonly attribute XRRigidTransform? gripTransform;
 };
 
 //


### PR DESCRIPTION
Part of a solution to address #431. We've also heard from several developers that they end up decomposing the view matrices we supply so they can apply a translation and rotation to their engine's camera primitive, which feels annoying and error prone. This PR proposes that we start representing most transforms in the API as an actual transform interface, which includes a translation vector and orientation quaternion. (Both as `DOMPointReadOnly`) It also provides a Float32Array matrix attribute (which can be lazily evaluated for performance reasons) as a convenience.

Using a transform interface like this will allow transform inputs into the API (such as for teleportation in the follow-up PR) to enforce constraints that a simple matrix would not, such as ensuring that there is no shearing or other weirdness that wouldn't work well in that context.

The XRView providing view and projection matrices direction is not changed in this PR. The view matrix is because this is about the only situation where the API would need to provide an inverted matrix, so it doesn't feel too bad as a one-off and avoids cluttering the `XRRigidTransform` with a more confusing, general case attribute like `invertedMatrix`. The projection matrix is still provided directly because it is still my understanding that some platforms need to express projections that don't fit cleanly into, say, an FOV struct.