### PR TITLE
Add application-defined Reference space transforms ("Teleportation")

### DIFF
--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -178,11 +178,9 @@ function onSessionStarted(session) {
 ```
 
 ### Application-supplied transforms
-Frequently developers will want to provide an additional, artificial transform on top of the user's tracked motion to allow the user to navigate larger scenes than their tracking systems or physical space allows. An examples of this would be the common "teleportation" mechanic, where the user selects a point in the virtual scene to "jump" to, after which the selected point is treated as the new origin which all tracked motion is relative to. This effect is traditionally accomplished by mathematically combining the API-provided transform with the desired additional application transforms. It is useful to allow the API do handle it, however, because it ensures that all tracked values are transformed consistently, allowing the user's viewpoint and inputs to stay in sync.
+Frequently developers will want to provide an additional, artificial transform on top of the user's tracked motion to allow the user to navigate larger scenes than their tracking systems or physical space allows. This effect is traditionally accomplished by mathematically combining the API-provided transform with the desired additional application transforms. It is useful to allow the API do handle it, however, because it ensures that all tracked values are transformed consistently, allowing the user's viewpoint and inputs to stay in sync.
 
-Developers can specify application-specific transforms by setting the `baseTransform` attribute of any `XRReferenceSpace`. When the `transform` is not null, any values queried using the `XRReferenceSpace` will be offset by the `translation` and `orientation` the `baseTransform` describes. The `XRReferenceSpace`'s `baseTransform` can be updated at any time and will immediately take effect, meaning that any new values that are queried with the `XRReferenceSpace` will take into account the new `baseTransform`. Previously queried values will not be altered. Changing the `baseTransform` between pose queries in a single frame is not advised, since it will cause inconsistencies in the tracking data and rendered output.
-
-When interpreting an `XRRigidTransform` the `orientation` is applied prior to the `translation`. This means that, for example, a transform that indicates a quarter rotation to the right and a 1 meter translation along -Z would place a transformed object at `[0, 0, -1]` facing to the right.
+Developers can specify application-specific transforms by setting the `originTransform` attribute of any `XRReferenceSpace`. When the `transform` is not null, any values queried using the `XRReferenceSpace` will be offset by the `position` and `orientation` the `originTransform` describes. The `XRReferenceSpace`'s `originTransform` can be updated at any time and will immediately take effect, meaning that any new values that are queried with the `XRReferenceSpace` will take into account the new `originTransform`. Previously queried values will not be altered. Changing the `originTransform` between pose queries in a single frame is not advised, since it will cause inconsistencies in the tracking data and rendered output.
 
 The following example demonstrates how to create a `floor-level` reference space to account for a scene where the user is intended to start at a location 2 meters to the right and 3 meters back from the scene's origin.
 
@@ -195,12 +193,26 @@ function onSessionStarted(session) {
   xrSession.requestReferenceSpace({ type:'stationary', subtype:'floor-level' })
   .then((referenceSpace) => {
     xrReferenceSpace = referenceSpace;
-    xrReferenceSpace.baseTransform = new XRRigidTransform({ x: 2, z: 3 });
+    xrReferenceSpace.originTransform = new XRRigidTransform({ x: 2, z: 3 });
   })
   .then(setupWebGLLayer)
   .then(() => {
     xrSession.requestAnimationFrame(onDrawFrame);
   });
+}
+```
+
+Another common use case for this attribute would be for a "teleportation" mechanic, where the user "jumps" to a new point in the virtual scene, after which the selected point is treated as the new origin which all tracked motion is relative to.
+
+```js
+// Teleport the user a certain number of meters along the X, Y, and Z axes
+function teleport(deltaX, deltaY, deltaZ) {
+  let currentOrigin = xrReferenceSpace.originTransform;
+  xrReferenceSpace.originTransform = new XRRigidTransform(
+      { x: currentOrigin.position.x + deltaX,
+        y: currentOrigin.position.y + deltaY,
+        z: currentOrigin.position.z + deltaZ },
+      currentOrigin.orientation);
 }
 ```
 
@@ -260,7 +272,7 @@ Additionally, XR hardware with orientation-only tracking may also provide an emu
 There are several circumstances in which developers may choose to relate content in different reference spaces.
 
 #### Inline to Immersive
-It is expected that developers will often choose to preview `immersive` experiences with a similar experience `inline`. In this situation, users often expect to see the scene from the same perspective when they make the transition from `inline` to `immersive`. To accomplish this, developers should grab the `transform` of the last `XRViewerPose` retrieved using the `inline` session's `XRReferenceSpace` and set it as the `baseTransform` of the `immersive` session's `XRReferenceSpace`. The same logic applies in the reverse when exiting `immersive`.
+It is expected that developers will often choose to preview `immersive` experiences with a similar experience `inline`. In this situation, users often expect to see the scene from the same perspective when they make the transition from `inline` to `immersive`. To accomplish this, developers should grab the `transform` of the last `XRViewerPose` retrieved using the `inline` session's `XRReferenceSpace` and set it as the `originTransform` of the `immersive` session's `XRReferenceSpace`. The same logic applies in the reverse when exiting `immersive`.
 
 #### Unbounded to Bounded 
 When building an experience that is predominantly based on an `XRUnboundedReferenceSpace`, developers may occasionally choose to switch to an `XRBoundedReferenceSpace`.  For example, a whole-home renovation experience might choose to switch to a bounded reference space for reviewing a furniture selection library.  If necessary to continue displaying content belonging to the previous reference space, developers may use the `getTransformTo()` method to re-parent nearby virtual content to the new reference space.
@@ -392,7 +404,7 @@ dictionary XRReferenceSpaceOptions {
 };
 
 [SecureContext, Exposed=Window] interface XRReferenceSpace : XRSpace {  
-  attribute XRRigidTransform? baseTransform;
+  attribute XRRigidTransform? originTransform;
 
   attribute EventHandler onreset;
 };

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -178,7 +178,7 @@ function onSessionStarted(session) {
 ```
 
 ### Application-supplied transforms
-Frequently developers will want to provide an additional, artificial transform on top of the user's tracked motion to allow the user to navigate larger scenes than their tracking systems or physical space allows. This effect is traditionally accomplished by mathematically combining the API-provided transform with the desired additional application transforms. It is useful to allow the API do handle it, however, because it ensures that all tracked values are transformed consistently, allowing the user's viewpoint and inputs to stay in sync.
+Frequently developers will want to provide an additional, artificial transform on top of the user's tracked motion to allow the user to navigate larger virtual scenes than their tracking systems or physical space allows. This effect is traditionally accomplished by mathematically combining the API-provided transform with the desired additional application transforms. WebXR offers developers a simplification to ensure that all tracked values are transformed consistently, allowing the user's viewpoint and inputs to stay in sync.
 
 Developers can specify application-specific transforms by setting the `originTransform` attribute of any `XRReferenceSpace`. When the `transform` is not null, any values queried using the `XRReferenceSpace` will be offset by the `position` and `orientation` the `originTransform` describes. The `XRReferenceSpace`'s `originTransform` can be updated at any time and will immediately take effect, meaning that any new values that are queried with the `XRReferenceSpace` will take into account the new `originTransform`. Previously queried values will not be altered. Changing the `originTransform` between pose queries in a single frame is not advised, since it will cause inconsistencies in the tracking data and rendered output.
 
@@ -202,7 +202,7 @@ function onSessionStarted(session) {
 }
 ```
 
-Another common use case for this attribute would be for a "teleportation" mechanic, where the user "jumps" to a new point in the virtual scene, after which the selected point is treated as the new origin which all tracked motion is relative to.
+Another common use case for this attribute would be for a "teleportation" mechanic, where the user "jumps" to a new point in the virtual scene, after which the selected point is treated as the new virtual origin which all tracked motion is relative to.
 
 ```js
 // Teleport the user a certain number of meters along the X, Y, and Z axes
@@ -404,7 +404,7 @@ dictionary XRReferenceSpaceOptions {
 };
 
 [SecureContext, Exposed=Window] interface XRReferenceSpace : XRSpace {  
-  attribute XRRigidTransform? originTransform;
+  attribute XRRigidTransform originTransform;
 
   attribute EventHandler onreset;
 };


### PR DESCRIPTION
Follow up to #440, second part of a solution to #431. This PR adds the ability for developers to specify a transform to any `XRReferenceSpace` that will be applied to any sensor-controlled poses, effectively giving developers a simple method of "teleporting" the user around a scene. (That's a bit over-specific, since this also allows for things like touch/mouse rotation of magic window content and continuous stick motion if you have the stomach for it.)

Technically this is something that any dev can do themselves, but it means ensuring that you're consistently applying the transform to all your inputs, manually reversing it out for things like hit testing, and inverting, applying, and re-inverting in order to apply to view matrices. Thus handling it in the API is a significant convenience (that developers can still ignore if they are so inclined). It's also something that can be handled entirely at the API implementation level and won't need specialized logic for every native backend, so realistically the code will need to be written ~3 times and then everyone benefits forever. 

As mentioned in #440, the fact that this uses an `XRRigidTransform` rather than a raw `Float32Array` matrix is important because it allows us to impose constraints/validation on the types of transforms being done. No weird shearing, for example.