### PR TITLE
baseLayer is nullable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -302,7 +302,7 @@ enum XREnvironmentBlendMode {
 [SecureContext, Exposed=Window] interface XRSession : EventTarget {
   // Attributes
   readonly attribute XRSessionMode mode;
-  readonly attribute XRPresentationContext outputContext;
+  readonly attribute XRPresentationContext? outputContext;
   readonly attribute XREnvironmentBlendMode environmentBlendMode;
 
   attribute double depthNear;
@@ -451,7 +451,7 @@ The {{XRSessionCreationOptions}} dictionary provides a <dfn>session description<
 <pre class="idl">
 dictionary XRSessionCreationOptions {
   XRSessionMode mode = "inline";
-  XRPresentationContext outputContext;
+  XRPresentationContext outputContext? = null;
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -307,7 +307,7 @@ enum XREnvironmentBlendMode {
 
   attribute double depthNear;
   attribute double depthFar;
-  attribute XRLayer baseLayer;
+  attribute XRLayer? baseLayer;
 
   // Methods
   Promise&lt;XRReferenceSpace&gt; requestReferenceSpace(XRReferenceSpaceType type, optional XRReferenceSpaceOptions options);


### PR DESCRIPTION
baseLayer is null after construction, so the attribute must be nullable