### PR TITLE
Fix bug in WebIDL definition of XRSessionCreationOptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -451,7 +451,7 @@ The {{XRSessionCreationOptions}} dictionary provides a <dfn>session description<
 <pre class="idl">
 dictionary XRSessionCreationOptions {
   XRSessionMode mode = "inline";
-  XRPresentationContext outputContext? = null;
+  XRPresentationContext? outputContext = null;
 };
 </pre>
 


### PR DESCRIPTION
The nullable marker is on the type, not the name of the dictionary member