### PR TITLE
[Editional] Fixed metadata/status from w3c/ED to ED

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Shortname: webxr
 Title: WebXR Device API
 Group: immersivewebwg
-Status: w3c/ED
+Status: ED
 ED: https://immersive-web.github.io/webxr/
 Repository: immersive-web/webxr
 Level: 1


### PR DESCRIPTION
Status metadata does not need "w3c/"