### PR TITLE
 Add inlineVerticalFieldOfView to XRRenderState

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -555,6 +555,23 @@ function drawScene() {
 }
 ```
 
+### Changing the Field of View for inline sessions
+
+Whenever possible projection matrices delivered by the API should make use of physical properties such as the headset optics or camera lens to determine the field of view to use. However, for most inline content there isn't any physically based values to draw from. In order to provide a unified render pipeline for inline content an arbitrary field of view must be selected.
+
+By default a vertical field of view of 0.5 radians (90 degrees) is used when no physically-based field of view is provided. The horizontal field of view is computed from the vertical field of view based on the width/height ratio of the `outputContext`'s canvas.
+
+If a different default field of view is desired, it can be specified by passing a new `defaultVerticalFieldOfView` value, in radians, to the `updateRenderState` method:
+
+```js
+// This changes the default vertical field of view to 0.4 radians (72 degrees).
+xrSession.updateRenderState({
+  defaultVerticalFieldOfView: 0.4 * Math.PI,
+});
+```
+
+The UA is allowed to clamp the value, and it is expected that if any physically-based values are available they should always be used in favor of the default.
+
 ## Appendix A: I don’t understand why this is a new API. Why can’t we use…
 
 ### `DeviceOrientation` Events
@@ -646,6 +663,7 @@ enum XREnvironmentBlendMode {
 dictionary XRRenderStateInit {
   double depthNear;
   double depthFar;
+  double defaultVerticalFieldOfView;
   XRLayer? baseLayer;
   XRPresentationContext? outputContext
 };
@@ -653,6 +671,7 @@ dictionary XRRenderStateInit {
 [SecureContext, Exposed=Window] interface XRRenderState {
   readonly attribute double depthNear;
   readonly attribute double depthFar;
+  readonly attribute double defaultVerticalFieldOfView;
   readonly attribute XRLayer? baseLayer;
   readonly attribute XRPresentationContext? outputContext;
 };

--- a/explainer.md
+++ b/explainer.md
@@ -557,20 +557,22 @@ function drawScene() {
 
 ### Changing the Field of View for inline sessions
 
-Whenever possible projection matrices delivered by the API should make use of physical properties such as the headset optics or camera lens to determine the field of view to use. However, for most inline content there aren't any physically based values from which to infer a field of view. In order to provide a unified render pipeline for inline content an arbitrary field of view must be selected.
+Whenever possible the matrices given by `XRView`'s `projectionMatrix` attribute should make use of physical properties, such as the headset optics or camera lens, to determine the field of view to use. Most inline content, however, won't have any physically based values from which to infer a field of view. In order to provide a unified render pipeline for inline content an arbitrary field of view must be selected.
 
 By default a vertical field of view of 0.5 radians (90 degrees) is used for inline sessions. The horizontal field of view can be computed from the vertical field of view based on the width/height ratio of the `outputContext`'s canvas.
 
-If a different default field of view is desired, it can be specified by passing a new `verticalFieldOfView` value, in radians, to the `updateRenderState` method:
+If a different default field of view is desired, it can be specified by passing a new `defaultFieldOfView` value, in radians, to the `updateRenderState` method:
 
 ```js
 // This changes the vertical field of view to 0.4 radians (72 degrees).
 xrSession.updateRenderState({
-  verticalFieldOfView: 0.4 * Math.PI,
+  defaultFieldOfView: 0.4 * Math.PI,
 });
 ```
 
-The UA is allowed to clamp the value, and if any physically-based values are available they must always be used in favor of developer supplied values. Attempting to set a `verticalFieldOfView` value on an immersive session will cause `updateRenderState()` to throw an `InvalidStateError`.
+The UA is allowed to clamp the value, and if a physically-based field of view is available it must always be used in favor of the default value.
+
+Attempting to set a `defaultFieldOfView` value on an immersive session will cause `updateRenderState()` to throw an `InvalidStateError`. `XRRenderState.defaultFieldOfView` must return `null` on immersive sessions.
 
 ## Appendix A: I don’t understand why this is a new API. Why can’t we use…
 
@@ -663,7 +665,7 @@ enum XREnvironmentBlendMode {
 dictionary XRRenderStateInit {
   double depthNear;
   double depthFar;
-  double verticalFieldOfView;
+  double defaultFieldOfView;
   XRLayer? baseLayer;
   XRPresentationContext? outputContext
 };
@@ -671,7 +673,7 @@ dictionary XRRenderStateInit {
 [SecureContext, Exposed=Window] interface XRRenderState {
   readonly attribute double depthNear;
   readonly attribute double depthFar;
-  readonly attribute double verticalFieldOfView;
+  readonly attribute double? defaultFieldOfView;
   readonly attribute XRLayer? baseLayer;
   readonly attribute XRPresentationContext? outputContext;
 };

--- a/explainer.md
+++ b/explainer.md
@@ -557,20 +557,20 @@ function drawScene() {
 
 ### Changing the Field of View for inline sessions
 
-Whenever possible projection matrices delivered by the API should make use of physical properties such as the headset optics or camera lens to determine the field of view to use. However, for most inline content there aren't any physically based values to draw from. In order to provide a unified render pipeline for inline content an arbitrary field of view must be selected.
+Whenever possible projection matrices delivered by the API should make use of physical properties such as the headset optics or camera lens to determine the field of view to use. However, for most inline content there aren't any physically based values from which to infer a field of view. In order to provide a unified render pipeline for inline content an arbitrary field of view must be selected.
 
 By default a vertical field of view of 0.5 radians (90 degrees) is used for inline sessions. The horizontal field of view can be computed from the vertical field of view based on the width/height ratio of the `outputContext`'s canvas.
 
 If a different default field of view is desired, it can be specified by passing a new `verticalFieldOfView` value, in radians, to the `updateRenderState` method:
 
 ```js
-// This changes the default vertical field of view to 0.4 radians (72 degrees).
+// This changes the vertical field of view to 0.4 radians (72 degrees).
 xrSession.updateRenderState({
   verticalFieldOfView: 0.4 * Math.PI,
 });
 ```
 
-The UA is allowed to clamp the value, and it is expected that if any physically-based values are available they should always be used in favor of the default. Attempting to set a `verticalFieldOfView` value on an immersive session will cause `updateRenderState()` to throw an `InvalidStateError`.
+The UA is allowed to clamp the value, and if any physically-based values are available they must always be used in favor of developer supplied values. Attempting to set a `verticalFieldOfView` value on an immersive session will cause `updateRenderState()` to throw an `InvalidStateError`.
 
 ## Appendix A: I don’t understand why this is a new API. Why can’t we use…
 

--- a/explainer.md
+++ b/explainer.md
@@ -557,20 +557,20 @@ function drawScene() {
 
 ### Changing the Field of View for inline sessions
 
-Whenever possible projection matrices delivered by the API should make use of physical properties such as the headset optics or camera lens to determine the field of view to use. However, for most inline content there isn't any physically based values to draw from. In order to provide a unified render pipeline for inline content an arbitrary field of view must be selected.
+Whenever possible projection matrices delivered by the API should make use of physical properties such as the headset optics or camera lens to determine the field of view to use. However, for most inline content there aren't any physically based values to draw from. In order to provide a unified render pipeline for inline content an arbitrary field of view must be selected.
 
-By default a vertical field of view of 0.5 radians (90 degrees) is used when no physically-based field of view is provided. The horizontal field of view is computed from the vertical field of view based on the width/height ratio of the `outputContext`'s canvas.
+By default a vertical field of view of 0.5 radians (90 degrees) is used for inline sessions. The horizontal field of view can be computed from the vertical field of view based on the width/height ratio of the `outputContext`'s canvas.
 
-If a different default field of view is desired, it can be specified by passing a new `defaultVerticalFieldOfView` value, in radians, to the `updateRenderState` method:
+If a different default field of view is desired, it can be specified by passing a new `verticalFieldOfView` value, in radians, to the `updateRenderState` method:
 
 ```js
 // This changes the default vertical field of view to 0.4 radians (72 degrees).
 xrSession.updateRenderState({
-  defaultVerticalFieldOfView: 0.4 * Math.PI,
+  verticalFieldOfView: 0.4 * Math.PI,
 });
 ```
 
-The UA is allowed to clamp the value, and it is expected that if any physically-based values are available they should always be used in favor of the default.
+The UA is allowed to clamp the value, and it is expected that if any physically-based values are available they should always be used in favor of the default. Attempting to set a `verticalFieldOfView` value on an immersive session will cause `updateRenderState()` to throw an `InvalidStateError`.
 
 ## Appendix A: I don’t understand why this is a new API. Why can’t we use…
 
@@ -663,7 +663,7 @@ enum XREnvironmentBlendMode {
 dictionary XRRenderStateInit {
   double depthNear;
   double depthFar;
-  double defaultVerticalFieldOfView;
+  double verticalFieldOfView;
   XRLayer? baseLayer;
   XRPresentationContext? outputContext
 };
@@ -671,7 +671,7 @@ dictionary XRRenderStateInit {
 [SecureContext, Exposed=Window] interface XRRenderState {
   readonly attribute double depthNear;
   readonly attribute double depthFar;
-  readonly attribute double defaultVerticalFieldOfView;
+  readonly attribute double verticalFieldOfView;
   readonly attribute XRLayer? baseLayer;
   readonly attribute XRPresentationContext? outputContext;
 };

--- a/explainer.md
+++ b/explainer.md
@@ -561,18 +561,19 @@ Whenever possible the matrices given by `XRView`'s `projectionMatrix` attribute 
 
 By default a vertical field of view of 0.5 radians (90 degrees) is used for inline sessions. The horizontal field of view can be computed from the vertical field of view based on the width/height ratio of the `outputContext`'s canvas.
 
-If a different default field of view is desired, it can be specified by passing a new `defaultFieldOfView` value, in radians, to the `updateRenderState` method:
+If a different default field of view is desired, it can be specified by passing a new `verticalFieldOfView` value, in radians, to the `updateRenderState` method:
 
 ```js
-// This changes the vertical field of view to 0.4 radians (72 degrees).
+// This changes the default vertical field of view for an inline session to
+// 0.4 radians (72 degrees).
 xrSession.updateRenderState({
-  defaultFieldOfView: 0.4 * Math.PI,
+  verticalFieldOfView: 0.4 * Math.PI,
 });
 ```
 
 The UA is allowed to clamp the value, and if a physically-based field of view is available it must always be used in favor of the default value.
 
-Attempting to set a `defaultFieldOfView` value on an immersive session will cause `updateRenderState()` to throw an `InvalidStateError`. `XRRenderState.defaultFieldOfView` must return `null` on immersive sessions.
+Attempting to set a `verticalFieldOfView` value on an immersive session will cause `updateRenderState()` to throw an `InvalidStateError`. `XRRenderState.verticalFieldOfView` must return `null` on immersive sessions.
 
 ## Appendix A: I don’t understand why this is a new API. Why can’t we use…
 
@@ -665,7 +666,7 @@ enum XREnvironmentBlendMode {
 dictionary XRRenderStateInit {
   double depthNear;
   double depthFar;
-  double defaultFieldOfView;
+  double verticalFieldOfView;
   XRLayer? baseLayer;
   XRPresentationContext? outputContext
 };
@@ -673,7 +674,7 @@ dictionary XRRenderStateInit {
 [SecureContext, Exposed=Window] interface XRRenderState {
   readonly attribute double depthNear;
   readonly attribute double depthFar;
-  readonly attribute double? defaultFieldOfView;
+  readonly attribute double? verticalFieldOfView;
   readonly attribute XRLayer? baseLayer;
   readonly attribute XRPresentationContext? outputContext;
 };

--- a/explainer.md
+++ b/explainer.md
@@ -561,19 +561,19 @@ Whenever possible the matrices given by `XRView`'s `projectionMatrix` attribute 
 
 By default a vertical field of view of 0.5 radians (90 degrees) is used for inline sessions. The horizontal field of view can be computed from the vertical field of view based on the width/height ratio of the `outputContext`'s canvas.
 
-If a different default field of view is desired, it can be specified by passing a new `verticalFieldOfView` value, in radians, to the `updateRenderState` method:
+If a different default field of view is desired, it can be specified by passing a new `inlineVerticalFieldOfView` value, in radians, to the `updateRenderState` method:
 
 ```js
 // This changes the default vertical field of view for an inline session to
 // 0.4 radians (72 degrees).
 xrSession.updateRenderState({
-  verticalFieldOfView: 0.4 * Math.PI,
+  inlineVerticalFieldOfView: 0.4 * Math.PI,
 });
 ```
 
 The UA is allowed to clamp the value, and if a physically-based field of view is available it must always be used in favor of the default value.
 
-Attempting to set a `verticalFieldOfView` value on an immersive session will cause `updateRenderState()` to throw an `InvalidStateError`. `XRRenderState.verticalFieldOfView` must return `null` on immersive sessions.
+Attempting to set a `inlineVerticalFieldOfView` value on an immersive session will cause `updateRenderState()` to throw an `InvalidStateError`. `XRRenderState.inlineVerticalFieldOfView` must return `null` on immersive sessions.
 
 ## Appendix A: I don’t understand why this is a new API. Why can’t we use…
 
@@ -666,7 +666,7 @@ enum XREnvironmentBlendMode {
 dictionary XRRenderStateInit {
   double depthNear;
   double depthFar;
-  double verticalFieldOfView;
+  double inlineVerticalFieldOfView;
   XRLayer? baseLayer;
   XRPresentationContext? outputContext
 };
@@ -674,7 +674,7 @@ dictionary XRRenderStateInit {
 [SecureContext, Exposed=Window] interface XRRenderState {
   readonly attribute double depthNear;
   readonly attribute double depthFar;
-  readonly attribute double? verticalFieldOfView;
+  readonly attribute double? inlineVerticalFieldOfView;
   readonly attribute XRLayer? baseLayer;
   readonly attribute XRPresentationContext? outputContext;
 };

--- a/index.bs
+++ b/index.bs
@@ -420,7 +420,7 @@ When the <dfn method for="XRSession">updateRenderState(|newState|)</dfn> method 
   1. Let |session| be the target {{XRSession}}.
   1. If |session|'s [=ended=] value is <code>true</code>, throw an {{InvalidStateError}} and abort these steps.
   1. If |newState|'s {{XRRenderStateInit/baseLayer}}'s was created with an {{XRSession}} other than |session|, throw an {{InvalidStateError}} and abort these steps.
-  1. If |newState|'s {{XRRenderStateInit/inlineVerticalFieldOfView}} is set and |session|'s {{XRSession/mode}} is not {{XRSessionMode/inline}}, throw an {{InvalidStateError}} and abort these steps.
+  1. If |newState|'s {{XRRenderStateInit/inlineVerticalFieldOfView}} is set and |session| is an [=immersive session=], throw an {{InvalidStateError}} and abort these steps.
   1. Append |newState| to |session|'s [=list of pending render states=].
 
 </div>
@@ -570,8 +570,8 @@ When an {{XRRenderState}} object is created for an {{XRSession}} |session|, the 
   1. Let |state| be the newly created {{XRRenderState}} object.
   1. Initialize |state|'s {{XRRenderState/depthNear}} to <code>0.1</code>.
   1. Initialize |state|'s {{XRRenderState/depthFar}} to <code>1000.0</code>.
-  1. If |session|'s {{XRSession/mode}} is {{XRSessionMode/inline}}, initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} to <code>PI * 0.5</code>.
-  1. Else initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} to <code>null</code>.
+  1. If |session| is an [=immersive session=], initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} to <code>null</code>.
+  1. Else initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} to <code>PI * 0.5</code>.
   1. Initialize |state|'s {{XRRenderState/baseLayer}} to <code>null</code>.
   1. Initialize |state|'s {{XRRenderState/outputContext}} to <code>null</code>.
 
@@ -581,7 +581,7 @@ The <dfn attribute for="XRRenderState">depthNear</dfn> attribute defines the dis
 
 {{XRRenderState/depthNear}} and {{XRRenderState/depthFar}} is used in the computation of the {{XRView/projectionMatrix}} of {{XRView}}s and determines how the values of an {{XRWebGLLayer}} depth buffer are interpreted. {{XRRenderState/depthNear}} MAY be greater than {{XRRenderState/depthFar}}.
 
-The <dfn attribute for="XRRenderState">inlineVerticalFieldOfView</dfn> attribute defines the default vertical field of view in radians used when computing projection matrices for {{XRSessionMode/inline}} {{XRSession}}s. The projection matrix calculation also takes into account the aspect ratio of the {{XRRenderState/outputContext}}'s {{XRPresentationContext/canvas}}. This value MUST be <code>null</code> for {{XRSessionMode/immersive-vr}} and {{XRSessionMode/immersive-ar}} {{XRSession}}s.
+The <dfn attribute for="XRRenderState">inlineVerticalFieldOfView</dfn> attribute defines the default vertical field of view in radians used when computing projection matrices for {{XRSessionMode/inline}} {{XRSession}}s. The projection matrix calculation also takes into account the aspect ratio of the {{XRRenderState/outputContext}}'s {{XRPresentationContext/canvas}}. This value MUST be <code>null</code> for [=immersive sessions=].
 
 Animation Frames {#animation-frames}
 ----------------

--- a/index.bs
+++ b/index.bs
@@ -411,6 +411,8 @@ Each {{XRSession}} has an <dfn>active render state</dfn> which is a new {{XRRend
 
 The <dfn attribute for="XRSession">renderState</dfn> attribute returns the {{XRSession}}'s [=active render state=].
 
+Each {{XRSession}} has a <dfn>minimum inline field of view</dfn> and a <dfn>maximum inline field of view</dfn>, defined in radians. The values MUST be determined by the user agent and MUST fall in the range of <code>0</code> to <code>PI</code>.
+
 <div class="algorithm" data-algorithm="update-render-state">
 
 When the <dfn method for="XRSession">updateRenderState(|newState|)</dfn> method is invoked, the user agent MUST run the following steps:
@@ -418,6 +420,7 @@ When the <dfn method for="XRSession">updateRenderState(|newState|)</dfn> method 
   1. Let |session| be the target {{XRSession}}.
   1. If |session|'s [=ended=] value is <code>true</code>, throw an {{InvalidStateError}} and abort these steps.
   1. If |newState|'s {{XRRenderStateInit/baseLayer}}'s was created with an {{XRSession}} other than |session|, throw an {{InvalidStateError}} and abort these steps.
+  1. If |newState|'s {{XRRenderStateInit/inlineVerticalFieldOfView}} is set and |session|'s {{XRSession/mode}} is not {{XRSessionMode/inline}}, throw an {{InvalidStateError}} and abort these steps.
   1. Append |newState| to |session|'s [=list of pending render states=].
 
 </div>
@@ -433,8 +436,11 @@ When requested, the {{XRSession}} MUST <dfn>apply pending render states</dfn> by
   1. For each |newState| in |pendingStates|:
     1. If |newState|'s {{XRRenderStateInit/depthNear}} value is set, set |activeState|'s {{XRRenderState/depthNear}} to |newState|'s {{XRRenderStateInit/depthNear}}.
     1. If |newState|'s {{XRRenderStateInit/depthFar}} value is set, set |activeState|'s {{XRRenderState/depthFar}} to |newState|'s {{XRRenderStateInit/depthFar}}.
+    1. If |newState|'s {{XRRenderStateInit/inlineVerticalFieldOfView}} is set, set |activeState|'s {{XRRenderState/inlineVerticalFieldOfView}} to |newState|'s {{XRRenderStateInit/inlineVerticalFieldOfView}}.
     1. If |newState|'s {{XRRenderStateInit/baseLayer}} is set, set |activeState|'s {{XRRenderState/baseLayer}} to |newState|'s {{XRRenderStateInit/baseLayer}}.
     1. If |newState|'s {{XRRenderStateInit/outputContext}} is set, set |activeState|'s {{XRRenderState/outputContext}} to |newState|'s {{XRRenderStateInit/outputContext}} and [=update the XRPresentationContext session=] to |session|.
+  1. If |activeState|'s {{XRRenderState/inlineVerticalFieldOfView}} is less than |session|'s [=minimum inline field of view=] set |activeState|'s {{XRRenderState/inlineVerticalFieldOfView}} to |session|'s [=minimum inline field of view=].
+  1. If |activeState|'s {{XRRenderState/inlineVerticalFieldOfView}} is greater than |session|'s [=maximum inline field of view=] set |activeState|'s {{XRRenderState/inlineVerticalFieldOfView}} to |session|'s [=maximum inline field of view=].
 
 </div>
 
@@ -543,6 +549,7 @@ There are multiple values that developers can configure which affect how the ses
 dictionary XRRenderStateInit {
   double depthNear;
   double depthFar;
+  double inlineVerticalFieldOfView;
   XRLayer? baseLayer;
   XRPresentationContext? outputContext;
 };
@@ -550,6 +557,7 @@ dictionary XRRenderStateInit {
 [SecureContext, Exposed=Window] interface XRRenderState {
   readonly attribute double depthNear;
   readonly attribute double depthFar;
+  readonly attribute double? inlineVerticalFieldOfView;
   readonly attribute XRLayer? baseLayer;
   readonly attribute XRPresentationContext? outputContext;
 };
@@ -557,11 +565,13 @@ dictionary XRRenderStateInit {
 
 <div class="algorithm" data-algorithm="initialize-renderstate">
 
-When an {{XRRenderState}} object is created, the user agent MUST <dfn>initialize the render state</dfn> by running the following steps:
+When an {{XRRenderState}} object is created for an {{XRSession}} |session|, the user agent MUST <dfn>initialize the render state</dfn> by running the following steps:
 
   1. Let |state| be the newly created {{XRRenderState}} object.
   1. Initialize |state|'s {{XRRenderState/depthNear}} to <code>0.1</code>.
   1. Initialize |state|'s {{XRRenderState/depthFar}} to <code>1000.0</code>.
+  1. If |session|'s {{XRSession/mode}} is {{XRSessionMode/inline}}, initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} to <code>PI * 0.5</code>.
+  1. Else initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} to <code>null</code>.
   1. Initialize |state|'s {{XRRenderState/baseLayer}} to <code>null</code>.
   1. Initialize |state|'s {{XRRenderState/outputContext}} to <code>null</code>.
 
@@ -570,6 +580,8 @@ When an {{XRRenderState}} object is created, the user agent MUST <dfn>initialize
 The <dfn attribute for="XRRenderState">depthNear</dfn> attribute defines the distance, in meters, of the near clip plane from the viewer. The <dfn attribute for="XRRenderState">depthFar</dfn> attribute defines the distance, in meters, of the far clip plane from the viewer. 
 
 {{XRRenderState/depthNear}} and {{XRRenderState/depthFar}} is used in the computation of the {{XRView/projectionMatrix}} of {{XRView}}s and determines how the values of an {{XRWebGLLayer}} depth buffer are interpreted. {{XRRenderState/depthNear}} MAY be greater than {{XRRenderState/depthFar}}.
+
+The <dfn attribute for="XRRenderState">inlineVerticalFieldOfView</dfn> attribute defines the default vertical field of view in radians used when computing projection matrices for {{XRSessionMode/inline}} {{XRSession}}s. The projection matrix calculation also takes into account the aspect ratio of the {{XRRenderState/outputContext}}'s {{XRPresentationContext/canvas}}. This value MUST be <code>null</code> for {{XRSessionMode/immersive-vr}} and {{XRSessionMode/immersive-ar}} {{XRSession}}s.
 
 Animation Frames {#animation-frames}
 ----------------


### PR DESCRIPTION
Fixes #272.

Pretty simple feature, based on the feedback from the F2F. It's apparent to me that we're not going to magically come up with a default value that has a good reason behind it, so I plugged 90deg in there just because it's a clean number that's easy to guess and gives reasonable results. Also left it as a single direction that can be specified (vertical) because you can pretty trivially do the math to convert from one to the other and vertical seems to be the value that most developers/game players are used to setting. (This because monitors are traditionally wider than tall and it's easier to get predictable results out of a single vertical FoV when jumping between 4:3 and 16:9 aspect ratios).