### PR TITLE
Changed XRHandedness enum to use 'none' instead of ''

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1022,7 +1022,7 @@ An {{XRInputSource}} represents any input mechanism which allows the user to per
 
 <pre class="idl">
 enum XRHandedness {
-  "",
+  "none",
   "left",
   "right"
 };
@@ -1044,7 +1044,7 @@ interface XRInputSource {
 
 Each {{XRInputSource}} SHOULD define a <dfn>primary action</dfn>. The [=primary action=] is a platform-specific action that, when engaged, produces {{selectstart}}, {{selectend}}, and {{XRSession/select}} events. Examples of possible [=primary action=]s are pressing a trigger, touchpad, or button, speaking a command, or making a hand gesture. If the platform guidelines define a recommended primary input then it should be used as the [=primary action=], otherwise the user agent is free to select one.
 
-The <dfn attribute for="XRInputSource">handedness</dfn> attribute describes which hand the input source is associated with, if any. Input sources with no natural handedness (such as headset-mounted controls or standard gamepads) or for which the handedness is not currently known MUST set this attribute to the empty string.
+The <dfn attribute for="XRInputSource">handedness</dfn> attribute describes which hand the input source is associated with, if any. Input sources with no natural handedness (such as headset-mounted controls or standard gamepads) or for which the handedness is not currently known MUST set this attribute {{XRHandedness/none}}.
 
 The <dfn attribute for="XRInputSource">targetRayMode</dfn> attribute describes the method used to produce the target ray, and indicates how the application should present the target ray to the user if desired.
 

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -267,7 +267,7 @@ partial interface XRSession {
 //
 
 enum XRHandedness {
-  "",
+  "none",
   "left",
   "right"
 };


### PR DESCRIPTION
Fixed #515.

Thanks to @HyroVitalyProtago for the suggestion! Empty string was definitely a weird enum, and so I do feel like it's appropriate to change it to a more representative string. I had suggested `neutral` in the issue, but upon thinking it through further I feel like @HyroVitalyProtago's original suggestion of `none` is more appropriate. This is because the input in question may not actually be associated with any hand at all, such as is the case with gaze input, whereas `neutral` implies to me that the input is actually associated with a hand but doesn't know or care which. i.e: A Vive wand that hasn't established it's spatial relationship yet strikes me as a "neutral" input device, while a cardboard device has no hand association whatsoever. In both cases `none` feels like an appropriate descriptor of the handedness.  