### PR TITLE
Remove viewMatrix and add XRTransform.inverse()

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -226,7 +226,7 @@ Once drawn to, the XR device will continue displaying the contents of the `XRWeb
 
 Each `XRFrame` the scene will be drawn from the perspective of a "viewer", which is the user or device viewing the scene, described by an `XRViewerPose`. Developers retrieve the current `XRViewerPose` by calling `getViewerPose()` on the `XRFrame` and providing an `XRReferenceSpace` for the pose to be returned in. Due to the nature of XR tracking systems, this function is not guaranteed to return a value and developers will need to respond appropriately. For more information about what situations will cause `getViewerPose()` to fail and recommended practices for handling the situation, refer to the [Spatial Tracking Explainer](spatial-tracking-explainer.md).
 
-The `XRViewerPose` contains a `views` attribute, which is an array of `XRView`s. Each `XRView` has a `viewMatrix` and a `projectionMatrix` that should be used when rendering with WebGL. The `XRView` is also passed to an `XRWebGLLayer`'s `getViewport()` method to determine what the WebGL viewport should be set to when rendering. This ensures that the appropriate perspectives of scene are rendered to the correct portion on the `XRWebGLLayer`'s `framebuffer` in order to display correctly on the XR hardware.
+The `XRViewerPose` contains a `views` attribute, which is an array of `XRView`s. Each `XRView` has a `projectionMatrix` and `transform` that should be used when rendering with WebGL. (See the [definition of an `XRRigidTransform`](spatial-tracking-explainer.md#rigid-transforms) in the spatial tracking explainer.) The `XRView` is also passed to an `XRWebGLLayer`'s `getViewport()` method to determine what the WebGL viewport should be set to when rendering. This ensures that the appropriate perspectives of scene are rendered to the correct portion on the `XRWebGLLayer`'s `framebuffer` in order to display correctly on the XR hardware.
 
 ```js
 function onDrawFrame(timestamp, xrFrame) {
@@ -262,7 +262,7 @@ function drawScene(view) {
   let viewMatrix = null;
   let projectionMatrix = null;
   if (view) {
-    viewMatrix = view.viewMatrix;
+    viewMatrix = view.transform.inverse().matrix;
     projectionMatrix = view.projectionMatrix;
   } else {
     viewMatrix = defaultViewMatrix;
@@ -275,7 +275,7 @@ function drawScene(view) {
 }
 ```
 
-Because the `XRViewerPose` inherits from `XRPose` it also contains a `transform` describing the position and orientation of the viewer as a whole relative to the `XRReferenceSpace` origin. This is primarily useful for rendering a visual representation of the viewer for spectator views or multi-user environments. Each `XRView` has a `transform` as well that can be used in lieu of the `viewMatrix` to position virtual cameras in the scene if the rendering library being used prefers. For more information on `XRRigidTransform`s, see [the spatial tracking explainer](spatial-tracking-explainer.md#rigid-transforms).
+Because the `XRViewerPose` inherits from `XRPose` it also contains a `transform` describing the position and orientation of the viewer as a whole relative to the `XRReferenceSpace` origin. This is primarily useful for rendering a visual representation of the viewer for spectator views or multi-user environments.
 
 ### Handling suspended sessions
 
@@ -663,7 +663,6 @@ enum XREye {
 [SecureContext, Exposed=Window] interface XRView {
   readonly attribute XREye eye;
   readonly attribute Float32Array projectionMatrix;
-  readonly attribute Float32Array viewMatrix;
   readonly attribute XRRigidTransform transform;
 };
 

--- a/index.bs
+++ b/index.bs
@@ -833,7 +833,6 @@ enum XREye {
 [SecureContext, Exposed=Window] interface XRView {
   readonly attribute XREye eye;
   readonly attribute Float32Array projectionMatrix;
-  readonly attribute Float32Array viewMatrix;
   readonly attribute XRRigidTransform transform;
 };
 </pre>
@@ -842,12 +841,9 @@ The <dfn attribute for="XRView">eye</dfn> attribute describes which eye this vie
 
 The <dfn attribute for="XRView">projectionMatrix</dfn> attribute provides a [=matrix=] describing the projection to be used when rendering the [=view=]. It is <b>strongly recommended</b> that applications use this matrix without modification. Failure to use the provided projection matrices when rendering may cause the presented frame to be distorted or badly aligned, resulting in varying degrees of user discomfort.
 
-The <dfn attribute for="XRView">viewMatrix</dfn> attribute provides a [=matrix=]
-describing the view transform to be used when rendering the [=view=]. The [=matrix=] represents the inverse of the {{XRView/transform}}'s {{XRRigidTransform/matrix}}. It is <b>strongly recommended</b> that applications use this matrix without modification. Failure to use the provided view matrices when rendering may cause the presented frame to be distorted or badly aligned, resulting in varying degrees of user discomfort.
+The <dfn attribute for="XRView">transform</dfn> attribute is the {{XRRigidTransform}} of the viewpoint.
 
-The <dfn attribute for="XRView">transform</dfn> attribute is the {{XRRigidTransform}} of the viewpoint. 
-
-NOTE: The {{XRView/transform}} can be used to position camera objects in many rendering libraries instead of using the {{XRView/viewMatrix}} directly if the library is more naturally set up to consume data in that format.
+NOTE: The {{XRView/transform}} can be used to position camera objects in many rendering libraries. If a more traditional view matrix is needed by the application one can be retrieved by calling `view.transform.inverse().matrix`.
 </section>
 
 XRViewport {#xrviewport-interface}
@@ -925,6 +921,8 @@ interface XRRigidTransform {
   readonly attribute DOMPointReadOnly position;
   readonly attribute DOMPointReadOnly orientation;
   readonly attribute Float32Array matrix;
+
+  XRRigidTransform inverse();
 };
 </pre>
 
@@ -949,6 +947,18 @@ The <dfn attribute for="XRRigidTransform">orientation</dfn> attribute is a quate
 The <dfn attribute for="XRRigidTransform">matrix</dfn> attribute returns the transform described by the {{XRRigidTransform/position}} and {{XRRigidTransform/orientation}} attributes as a [=matrix=].
 
 An {{XRRigidTransform}} with a {{XRRigidTransform/position}} of <code>{ x: 0, y: 0, z: 0 w: 1 }</code> and an {{XRRigidTransform/orientation}} of <code>{ x: 0, y: 0, z: 0, w: 1 }</code> is known as an <dfn>identity transform</dfn>.
+
+The {{XRRigidTransform/inverse()}} method returns an {{XRRigidTransform}} which, if applied to an object that had previously been transformed by the original {{XRRigidTransform}}, would undo the transform and return the object to it's initial pose.
+
+<div class="algorithm" data-algorithm="rigid-transform-inverse">
+
+When the <dfn method for="XRRigidTransform">inverse()</dfn> method is invoked, the user agent MUST run the following steps:
+
+  1. Figure out WTF the math that goes here should be.
+
+</div>
+
+ISSUE: Obviously the above algorithm should be written out prior to landing.
 
 XRRay {#xrray-interface}
 -----

--- a/index.bs
+++ b/index.bs
@@ -948,17 +948,7 @@ The <dfn attribute for="XRRigidTransform">matrix</dfn> attribute returns the tra
 
 An {{XRRigidTransform}} with a {{XRRigidTransform/position}} of <code>{ x: 0, y: 0, z: 0 w: 1 }</code> and an {{XRRigidTransform/orientation}} of <code>{ x: 0, y: 0, z: 0, w: 1 }</code> is known as an <dfn>identity transform</dfn>.
 
-The {{XRRigidTransform/inverse()}} method returns an {{XRRigidTransform}} which, if applied to an object that had previously been transformed by the original {{XRRigidTransform}}, would undo the transform and return the object to it's initial pose.
-
-<div class="algorithm" data-algorithm="rigid-transform-inverse">
-
-When the <dfn method for="XRRigidTransform">inverse()</dfn> method is invoked, the user agent MUST run the following steps:
-
-  1. Figure out WTF the math that goes here should be.
-
-</div>
-
-ISSUE: Obviously the above algorithm should be written out prior to landing.
+The {{XRRigidTransform/inverse()}} method returns a {{XRRigidTransform}} which, if applied to an object that had previously been transformed by the original {{XRRigidTransform}}, would undo the transform and return the object to it's initial pose.
 
 XRRay {#xrray-interface}
 -----

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -435,6 +435,8 @@ interface XRRigidTransform {
   readonly attribute DOMPointReadOnly position;
   readonly attribute DOMPointReadOnly orientation;
   readonly attribute Float32Array matrix;
+
+  XRRigidTransform inverse();
 };
 
 [SecureContext, Exposed=Window,


### PR DESCRIPTION
Fixes #447.

Ooh, hey! I'm gonna try GitHub's shiny new "Draft Pull Request" thingy here. ('Cuz this PR is clearly not quite there yet, but I feel it's worth discussing anyway.)

This was discussed on the IW call today, but I'll recap here: There's been some ongoing discussion about removing `XRView.viewMatrix` because it's computable from the values given in the `XRView.transform`. I've been a bit reluctant to do that simply because if someone *is* using the matrix then this makes it significantly more involved to get the same value back.

Separately, we had a discussion around the `originOffset` at the January 2019 Face to Face and one of the outcomes of that was that no matter how we chose to interpret the value given there we'd end up feeling "backwards" about 50% of the time.

This CL attempts to make both of those issues easier by introducing an `inverse()` method to the `XRRigidTransform` interface, which simply returns another `XRRigidTransform` that represents the opposite transform. ("inverse" rather than "invert" because the latter sounds like it modifies the object in place to me. Happy to take opposing opinions on that one.) The math to do this isn't terrible (though as you can tell from the CL I haven't fully worked out the algorithm yet) but it will be a big developer convenience if there's a mechanism to do it in the API.

With this function in place it means that developers that find that their use of `originOffset` is backwards from what they were expecting can correct it with a simple

```
referenceSpace.originOffset = transform.inverse();
```

Similarly, for developers that would really prefer to use a `viewMatrix` directly, the call now becomes

```
// Previously view.viewMatrix
view.transform.inverse().matrix;
```

Which is admittedly more verbose but also makes use of a more broadly applicable API mechanism rather than introducing data duplication that we presume most developers won't need.