### PR TITLE
Add ignoreDepthValues attribute to the XRWebGLLayer

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -520,6 +520,18 @@ xrSession.updateRenderState({
 });
 ```
 
+### Preventing the compositor from using the depth buffer
+
+By default the depth attachment of an `XRWebGLLayer`'s `framebuffer`, if present, may be used to assist the XR compositor. For example, the scene's depth values may be used by advanced reprojection techniques or to help avoid depth disparity when rendering platform/UA interfaces. This assumes, of course, that the values in the depth buffer are representative of the scene content.
+
+Some applications may violate that assumption, such as when using certain deferred rendering techniques or rendering stereo video. In those cases if the depth buffer's values are used by the compositor it may result in objectionable artifacts. To avoid this, the compositor can be instructed to ignore the depth values of an `XRWebGLLayer` by setting the `ignoreDepthValues` option to `true` at layer creation time:
+
+```js
+let webglLayer = new XRWebGLLayer(xrSession, gl, { ignoreDepthValues: true });
+```
+
+If `ignoreDepthValues` is not set to `true` the The UA is allowed (but not required) to use depth buffer as it sees fit. As a result, barring compositor access to the depth buffer in this way may lead to certain platform or UA features being unavailable or less robust.
+
 ### Handling non-opaque displays
 
 Some devices which support the WebXR Device API may use displays that are not fully opaque, or otherwise show your surrounding environment in some capacity. To determine how the display will blend rendered content with the real world, check the `XRSession`'s `environmentBlendMode` attribute. It may currently be one of three values, and more may be added in the future if new display technology necessitates it:
@@ -689,6 +701,7 @@ dictionary XRWebGLLayerInit {
   boolean depth = true;
   boolean stencil = false;
   boolean alpha = true;
+  boolean ignoreDepthValues = false;
   double framebufferScaleFactor = 1.0;
 };
 
@@ -705,6 +718,7 @@ interface XRWebGLLayer : XRLayer {
   readonly attribute boolean depth;
   readonly attribute boolean stencil;
   readonly attribute boolean alpha;
+  readonly attribute boolean ignoreDepthValues;
 
   readonly attribute unsigned long framebufferWidth;
   readonly attribute unsigned long framebufferHeight;

--- a/explainer.md
+++ b/explainer.md
@@ -522,7 +522,7 @@ xrSession.updateRenderState({
 
 ### Preventing the compositor from using the depth buffer
 
-By default the depth attachment of an `XRWebGLLayer`'s `framebuffer`, if present, may be used to assist the XR compositor. For example, the scene's depth values may be used by advanced reprojection techniques or to help avoid depth disparity when rendering platform/UA interfaces. This assumes, of course, that the values in the depth buffer are representative of the scene content.
+By default the depth attachment of an `XRWebGLLayer`'s `framebuffer`, if present, may be used to assist the XR compositor. For example, the scene's depth values may be used by advanced reprojection techniques or to help avoid depth conflicts when rendering platform/UA interfaces. This assumes, of course, that the values in the depth buffer are representative of the scene content.
 
 Some applications may violate that assumption, such as when using certain deferred rendering techniques or rendering stereo video. In those cases if the depth buffer's values are used by the compositor it may result in objectionable artifacts. To avoid this, the compositor can be instructed to ignore the depth values of an `XRWebGLLayer` by setting the `ignoreDepthValues` option to `true` at layer creation time:
 

--- a/index.bs
+++ b/index.bs
@@ -1185,7 +1185,11 @@ The <dfn attribute for="XRWebGLLayer">stencil</dfn> attribute is <code>true</cod
 
 The <dfn attribute for="XRWebGLLayer">alpha</dfn> attribute is <code>true</code> if the {{framebuffer}} has an alpha buffer attachment and <code>false</code> if no alpha buffer is attached.
 
-The <dfn attribute for="XRWebGLLayer">ignoreDepthValues</dfn> attribute, if <code>true</code>, indicates the [=XR Compositor=] MUST NOT make use of values in the depth buffer attachment when rendering. When the attribute is <code>false</code> it indicates that the content of the depth buffer attachment is expected to be representative of the scene rendered into the layer and the compositor MAY use it for effects such as improved reprojection.
+The <dfn attribute for="XRWebGLLayer">ignoreDepthValues</dfn> attribute, if <code>true</code>, indicates the [=XR Compositor=] MUST NOT make use of values in the depth buffer attachment when rendering. When the attribute is <code>false</code> it indicates that the content of the depth buffer attachment is expected to be representative of the scene rendered into the layer and MAY be used by the [=XR Compositor=].
+
+Depth values stored in the buffer are expected to be between <code>0.0</code> and <code>1.0</code>, with <code>0.0</code> representing the distance of {{XRRenderState/depthNear}} and <code>1.0</code> representing the distance of {{XRRenderState/depthFar}}, with intermediate values interpolated linearly. This is the default behavior of WebGL. (See documentation for the <a href="https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glDepthRangef.xml">depthRange function</a> for additional details.))
+
+NOTE: Making the scene's depth buffer available to the compositor allows some platforms to provide quality and comfort improvements such as improved reprojection.
 
 Each {{XRWebGLLayer}} MUST have a <dfn>list of viewports</dfn> which contains one [=WebGL viewport=] for each {{XRView}} the {{XRSession}} currently exposes. The viewports MUST NOT be overlapping. The {{XRWebGLLayer}} MUST also have a <dfn>viewport scale factor</dfn>, initially set to 1.0, and a <dfn>minimum viewport scale factor</dfn> set to a UA-determined value between 0 and 1.
 

--- a/index.bs
+++ b/index.bs
@@ -529,6 +529,10 @@ When an {{XRRenderState}} object is created, the user agent MUST <dfn>initialize
 
 </div>
 
+The <dfn attribute for="XRRenderState">depthNear</dfn> attribute defines the distance, in meters, of the near clip plane from the viewer. The <dfn attribute for="XRRenderState">depthFar</dfn> attribute defines the distance, in meters, of the far clip plane from the viewer. 
+
+{{XRRenderState/depthNear}} and {{XRRenderState/depthFar}} is used in the computation of the {{XRView/projectionMatrix}} of {{XRView}}s and determines how the values of an {{XRWebGLLayer}} depth buffer are interpreted. {{XRRenderState/depthNear}} MAY be greater than {{XRRenderState/depthFar}}.
+
 Animation Frames {#animation-frames}
 ----------------
 

--- a/index.bs
+++ b/index.bs
@@ -1116,6 +1116,7 @@ dictionary XRWebGLLayerInit {
   boolean depth = true;
   boolean stencil = false;
   boolean alpha = true;
+  boolean ignoreDepthValues = false;
   double framebufferScaleFactor = 1.0;
 };
 
@@ -1130,6 +1131,7 @@ interface XRWebGLLayer : XRLayer {
   readonly attribute boolean depth;
   readonly attribute boolean stencil;
   readonly attribute boolean alpha;
+  readonly attribute boolean ignoreDepthValues;
 
   readonly attribute WebGLFramebuffer framebuffer;
   readonly attribute unsigned long framebufferWidth;
@@ -1157,6 +1159,7 @@ The <dfn constructor for="XRWebGLLayer">XRWebGLLayer(|session|, |context|, |laye
   1. Initialize |layer|'s {{XRWebGLLayer/depth}} to |layerInit|'s {{XRWebGLLayerInit/depth}} value.
   1. Initialize |layer|'s {{XRWebGLLayer/stencil}} to |layerInit|'s {{XRWebGLLayerInit/stencil}} value.
   1. Initialize |layer|'s {{XRWebGLLayer/alpha}} to |layerInit|'s {{XRWebGLLayerInit/alpha}} value.
+  1. Initialize |layer|'s {{XRWebGLLayer/ignoreDepthValues}} to |layerInit|'s {{XRWebGLLayerInit/ignoreDepthValues}} value.
   1. Initialize |layer|'s {{XRWebGLLayer/framebuffer}} to a new [=opaque framebuffer=] created with |context|.
   1. Initialize the |layer|'s [=swap chain=].
   1. If |layer|'s [=swap chain=] was unable to be created for any reason, throw an {{OperationError}} and abort these steps.
@@ -1181,6 +1184,8 @@ The <dfn attribute for="XRWebGLLayer">depth</dfn> attribute is <code>true</code>
 The <dfn attribute for="XRWebGLLayer">stencil</dfn> attribute is <code>true</code> if the {{framebuffer}} has a stencil buffer attachment and <code>false</code> if no stencil buffer is attached.
 
 The <dfn attribute for="XRWebGLLayer">alpha</dfn> attribute is <code>true</code> if the {{framebuffer}} has an alpha buffer attachment and <code>false</code> if no alpha buffer is attached.
+
+The <dfn attribute for="XRWebGLLayer">ignoreDepthValues</dfn> attribute, if <code>true</code>, indicates the [=XR Compositor=] MUST NOT make use of values in the depth buffer attachment when rendering. When the attribute is <code>false</code> it indicates that the content of the depth buffer attachment is expected to be representative of the scene rendered into the layer and the compositor MAY use it for effects such as improved reprojection.
 
 Each {{XRWebGLLayer}} MUST have a <dfn>list of viewports</dfn> which contains one [=WebGL viewport=] for each {{XRView}} the {{XRSession}} currently exposes. The viewports MUST NOT be overlapping. The {{XRWebGLLayer}} MUST also have a <dfn>viewport scale factor</dfn>, initially set to 1.0, and a <dfn>minimum viewport scale factor</dfn> set to a UA-determined value between 0 and 1.
 


### PR DESCRIPTION
Fixes #523.

This value instructs the UA to prevent the values left in the depth buffer after a frame is rendered for compositing. Slightly concerned about potential for confusion regarding the `depth` and `ignoreDepthValues` attributes being on the same dictionary, so clarifying bikeshedding is welcome there if you have suggestions.

Given the scope of the feature it felt appropriate to handle both the spec text and explainer text in the same PR. Please take a look!