### PR TITLE
Explainer: requestReferenceSpace no longer takes an array

### DIFF
--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -300,17 +300,16 @@ let xrReferenceSpace = null;
 
 function onSessionStarted(session) {
   xrSession = session;
-  xrSession.requestReferenceSpace([
-    { type:'unbounded' }, 
-    { type:'stationary', subtype:'eye-level' }
-  ])
-  .then((referenceSpace) => {
+  // First request an unbounded frame of reference.
+  xrSession.requestReferenceSpace({ type:'unbounded' }).then((referenceSpace) => {
     xrReferenceSpace = referenceSpace;
-    if (xrReferenceSpace instanceof XRUnboundedReferenceSpace) {
-      // Set up unbounded experience
-    } else if (xrReferenceSpace instanceof XRStationaryReferenceSpace) {
-      // Build an appropriate fallback experience if needed; perhaps similar to the inline version
-    }
+  }).catch(() => {
+    // If an unbounded reference space is not available, request a stationary
+    // frame of reference as a fallback and adjust the experience as necessary.
+    return xrSession.requestReferenceSpace({ type:'stationary',
+                                             subtype:'eye-level' }).then((referenceSpace) => {
+      xrReferenceSpace = referenceSpace;
+    });
   })
   .then(setupWebGLLayer)
   .then(() => {
@@ -422,7 +421,7 @@ partial dictionary XRSessionCreationOptions {
 partial interface XRSession {
   readonly attribute XRSpace viewerSpace;
 
-  Promise<XRReferenceSpace> requestReferenceSpace(Array<XRReferenceSpaceOptions> preferredOptions);
+  Promise<XRReferenceSpace> requestReferenceSpace(XRReferenceSpaceOptions options);
 };
 
 //


### PR DESCRIPTION
As requested in #549.

This change brings the explainer's IDL signature back inline with the
version that's in the spec until we determine once and for all if we
should allow this function to accept an array or not.Tellingly, despite
multiple code examples using requestReferenceSpace only one, the one
explicitly showing the fallback behavior, was actually using the
"correct" form of the call prior to this PR.