### PR TITLE
Change XRRigidTransform inverse from a method to an attribute

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -262,7 +262,7 @@ function drawScene(view) {
   let viewMatrix = null;
   let projectionMatrix = null;
   if (view) {
-    viewMatrix = view.transform.inverse().matrix;
+    viewMatrix = view.transform.inverse.matrix;
     projectionMatrix = view.projectionMatrix;
   } else {
     viewMatrix = defaultViewMatrix;

--- a/index.bs
+++ b/index.bs
@@ -847,7 +847,7 @@ The <dfn attribute for="XRView">projectionMatrix</dfn> attribute provides a [=ma
 
 The <dfn attribute for="XRView">transform</dfn> attribute is the {{XRRigidTransform}} of the viewpoint.
 
-NOTE: The {{XRView/transform}} can be used to position camera objects in many rendering libraries. If a more traditional view matrix is needed by the application one can be retrieved by calling `view.transform.inverse().matrix`.
+NOTE: The {{XRView/transform}} can be used to position camera objects in many rendering libraries. If a more traditional view matrix is needed by the application one can be retrieved by calling `view.transform.inverse.matrix`.
 </section>
 
 XRViewport {#xrviewport-interface}
@@ -925,8 +925,7 @@ interface XRRigidTransform {
   readonly attribute DOMPointReadOnly position;
   readonly attribute DOMPointReadOnly orientation;
   readonly attribute Float32Array matrix;
-
-  XRRigidTransform inverse();
+  readonly attribute XRRigidTransform inverse;
 };
 </pre>
 
@@ -948,11 +947,11 @@ The <dfn attribute for="XRRigidTransform">position</dfn> attribute is a 3-dimens
 
 The <dfn attribute for="XRRigidTransform">orientation</dfn> attribute is a quaternion describing the rotational component of the transform. The {{XRRigidTransform/orientation}} MUST be normalized to have a length of <code>1.0</code>.
 
-The <dfn attribute for="XRRigidTransform">matrix</dfn> attribute returns the transform described by the {{XRRigidTransform/position}} and {{XRRigidTransform/orientation}} attributes as a [=matrix=].
+The <dfn attribute for="XRRigidTransform">matrix</dfn> attribute returns the transform described by the {{XRRigidTransform/position}} and {{XRRigidTransform/orientation}} attributes as a [=matrix=]. This attribute SHOULD be lazily evaluated.
+
+The <dfn attribute for="XRRigidTransform">inverse</dfn> attribute returns a {{XRRigidTransform}} which, if applied to an object that had previously been transformed by the original {{XRRigidTransform}}, would undo the transform and return the object to it's initial pose. This attribute SHOULD be lazily evaluated.
 
 An {{XRRigidTransform}} with a {{XRRigidTransform/position}} of <code>{ x: 0, y: 0, z: 0 w: 1 }</code> and an {{XRRigidTransform/orientation}} of <code>{ x: 0, y: 0, z: 0, w: 1 }</code> is known as an <dfn>identity transform</dfn>.
-
-The {{XRRigidTransform/inverse()}} method returns a {{XRRigidTransform}} which, if applied to an object that had previously been transformed by the original {{XRRigidTransform}}, would undo the transform and return the object to it's initial pose.
 
 XRRay {#xrray-interface}
 -----

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -434,8 +434,7 @@ interface XRRigidTransform {
   readonly attribute DOMPointReadOnly position;
   readonly attribute DOMPointReadOnly orientation;
   readonly attribute Float32Array matrix;
-
-  XRRigidTransform inverse();
+  readonly attribute XRRigidTransform inverse;
 };
 
 [SecureContext, Exposed=Window,


### PR DESCRIPTION
Suggesting this change based on a conversation with @bfgeek about API ergonomics. His assertion was that if the XRRigidTransform object was (and always would be) immutable (which it is) then it would make sense to have the inverse be exposed as an attribute (lazily evaluated, of course) rather than a method. Using a method for a case like this is appropriate in scenarios where the desired behavior is to return something based on the current snapshot of a mutable object's state. But since the XRRigidTransform is immutable (and therefore will only ever have one inverse) we could opt for the arguably simpler syntax.

Thoughts?