### PR TITLE
`boundsGeometry` must account for `originOffset`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -839,6 +839,8 @@ The <dfn attribute for="XRBoundedReferenceSpace">boundsGeometry</dfn> attribute 
 
 The polygonal boundary is given as an array of {{DOMPointReadOnly}}s, which represents a loop of points at the edges of the safe space. The points describe offsets from the {{XRReferenceSpace}} origin in meters. Points MUST be given in a clockwise order as viewed from above, looking towards the negative end of the Y axis. The {{DOMPointReadOnly/y}} value of each point MUST be <code>0</code> and the {{DOMPointReadOnly/w}} value of each point MUST be <code>1</code>. The bounds can be considered to originate at the floor and extend infinitely high. The shape it describes MAY be convex or concave.
 
+If the {{XRBoundedReferenceSpace}}'s {{originOffset}} is not an [=identity transform=] each point in the bounds array MUST be transformed by the {{XRRigidTransform/inverse}} of the {{originOffset}}. This ensures the bounds correctly align with the user's physical environment and always appear in the same location relative to the user by cancelling out the effects of the {{originOffset}}.
+
 Note: Content should not require the user to move beyond the {{boundsGeometry}}. It is possible for the user to move beyond the bounds if their physical surroundings allow for it, resulting in position values outside of the polygon they describe. This is not an error condition and should be handled gracefully by page content.
 
 Note: Content generally should not provide a visualization of the {{boundsGeometry}}, as it's the user agent's responsibility to ensure that safety critical information is provided to the user.


### PR DESCRIPTION
 Added a paragraph indicating that the `boundsGeometry` of an
 `XRBoundedReferenceSpace` MUST be transformed by `originOffset.inverse`
 in order to ensure it stays well-aligned to the physical environment.