### PR TITLE
Reject outstanding promises on session shut down

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -389,6 +389,7 @@ When an {{XRSession}} is shut down the following steps are run:
   1. Set |session|'s [=ended=] value to <code>true</code>.
   1. If the [=active immersive session=] is equal to |session|, set the [=active immersive session=] to <code>null</code>.
   1. Remove |session| from the [=list of inline sessions=].
+  1. [=Reject=] any outstanding promises returned by |session| with an {{InvalidStateError}}.
   1. If no other features of the user agent are actively using them, perform the necessary platform-specific steps to shut down the device's tracking and rendering capabilities.
 
 </div>


### PR DESCRIPTION
Fixes #556. Adds a catch-all statement that promises shouldn't outlive
the session they were returned from and indicates what error they should
reject with when the session shuts down.

Pinging @alcooper91 to take a look.