### PR TITLE
[Editiorial] Status metadata does not need "w3c/"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Shortname: webxr
 Title: WebXR Device API
 Group: immersivewebwg
-Status: w3c/ED
+Status: ED
 TR: https://www.w3.org/TR/webxr/
 ED: https://immersive-web.github.io/webxr/
 Repository: immersive-web/webxr


### PR DESCRIPTION
to fix regression at @2f84c43