### PR TITLE
Revert "[Editiorial] Status metadata does not need "w3c/""

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Shortname: webxr
 Title: WebXR Device API
 Group: immersivewebwg
-Status: ED
+Status: w3c/ED
 TR: https://www.w3.org/TR/webxr/
 ED: https://immersive-web.github.io/webxr/
 Repository: immersive-web/webxr


### PR DESCRIPTION
Reverts immersive-web/webxr#594