### PR TITLE
Edit requestSession() and Initialize the session

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -289,19 +289,19 @@ The {{XR}} object has a <dfn>pending immersive session</dfn> boolean, which MUST
 
 When the <dfn method for="XR">requestSession(|mode|)</dfn> method is invoked, the user agent MUST return [=a new Promise=] |promise| and run the following steps [=in parallel=]:
 
-  1. Let |immersive| be a boolean set to <code>true</code> if |mode| is {{immersive-vr}} or {{immersive-ar}} and <code>false</code> otherwise.
+  1. Let |immersive| be <code>true</code> if |mode| is {{XRSessionMode/"immersive-vr"}} or {{XRSessionMode/"immersive-ar"}}, and <code>false</code> otherwise.
   1. If |immersive| is <code>true</code>: 
-    1. If [=pending immersive session=] is <code>true</code> or [=active immersive session=] is not <code>null</code>, [=reject=] |promise| with an {{InvalidStateError}} and abort these steps.
+    1. If [=pending immersive session=] is <code>true</code> or [=active immersive session=] is not <code>null</code>, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}} and abort these steps.
     1. Else set [=pending immersive session=] to be <code>true</code>.
   1. [=ensures an XR device is selected|Ensure an XR device is selected=].
   1. If the [=XR/XR device=] is null, [=reject=] |promise| with null.
   1. Else if the [=XR/XR device=]'s [=list of supported modes=] does not [=list/contain=] |mode|, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
-  1. Else If |immersive| is <code>true</code> and the algorithm is not [=triggered by user activation=], [=reject=] |promise| with a {{SecurityError}} and abort these steps.
-  1. If |promise| was [=rejected=] and |immersive| is <code>true</code>, set [=pending immersive session=] to be <code>false</code>.
+  1. Else If |immersive| is <code>true</code> and the algorithm is not [=triggered by user activation=], [=reject=] |promise| with a "{{SecurityError}}" {{DOMException}} and abort these steps.
+  1. If |promise| was [=rejected=] and |immersive| is <code>true</code>, set [=pending immersive session=] to <code>false</code>.
   1. If |promise| was [=rejected=], abort these steps.
-  1. Let |session| be a new {{XRSession}}.
-  1. [=Initialize the session=] |session| with |mode|.
-  1. If |immersive| is <code>true</code> set the [=active immersive session=] to |session| and set [=pending immersive session=] to <code>false</code>.
+  1. Let |session| be a new {{XRSession}} object.
+  1. [=Initialize the session=] with |session| and |mode|.
+  1. If |immersive| is <code>true</code>, set the [=active immersive session=] to |session|, and set [=pending immersive session=] to <code>false</code>.
   1. Else append |session| to the [=list of inline sessions=].
   1. [=/Resolve=] |promise| with |session|.
 
@@ -387,15 +387,12 @@ enum XREnvironmentBlendMode {
 };
 </pre>
 
-Each {{XRSession}} has a <dfn for="XRSession">mode</dfn> which is the {{XRSessionMode}} it was created with.
+Each {{XRSession}} has a <dfn for="XRSession">mode</dfn>, which is one of the values of {{XRSessionMode}}.
 
 <div class="algorithm" data-algorithm="initialize-session">
 
-When an {{XRSession}} is created, the user agent MUST <dfn>initialize the session</dfn> by running the following steps:
-
-  1. Let |session| be the newly created {{XRSession}} object.
-  1. Let |mode| be the {{XRSessionMode}} passed to {{requestSession()}}.
-  1. Initialize |session|'s [=XRSession/mode=] to |mode|.
+To <dfn>initialize the session</dfn>, given |session| and |mode|, the user agent MUST run the following steps:
+  1. Set |session|'s [=XRSession/mode=] to |mode|.
   1. [=Initialize the render state=].
   1. If no other features of the user agent have done so already, perform the necessary platform-specific steps to initialize the device's tracking and rendering capabilities.
 
@@ -609,7 +606,7 @@ When an {{XRSession}} |session| receives updated [=viewer=] state from the [=/XR
 
   1. If |session|'s [=list of pending render states=] is not empty, [=apply pending render states=].
   1. If |session|'s {{XRSession/renderState}}'s {{XRRenderState/baseLayer}} is <code>null</code>, abort these steps.
-  1. If |session|'s  [=XRSession/mode=] is {{XRSessionMode/inline}} and |session|'s {{XRSession/renderState}}'s {{XRRenderState/outputContext}} is <code>null</code>, abort these steps.
+  1. If |session|'s  [=XRSession/mode=] is {{XRSessionMode/"inline"}} and |session|'s {{XRSession/renderState}}'s {{XRRenderState/outputContext}} is <code>null</code>, abort these steps.
   1. Let |callbacks| be a list of the entries in |session|'s [=list of animation frame callback=], in the order in which they were added to the list.
   1. Set |session|'s [=list of animation frame callbacks=] to the empty list.
   1. Set |frame|'s [=active=] boolean to <code>true</code>.


### PR DESCRIPTION
This change fixes strings to the XRSessionMode values, uses the same format for
DOMExceptions, and makes the Initialize the session algorithm more explicit by
defining parameters to it. This does not have any behavioral change.