### PR TITLE
Mark XRRenderState as [SameObject]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -362,7 +362,7 @@ enum XREnvironmentBlendMode {
 [SecureContext, Exposed=Window] interface XRSession : EventTarget {
   // Attributes
   readonly attribute XREnvironmentBlendMode environmentBlendMode;
-  readonly attribute XRRenderState renderState;
+  [SameObject] readonly attribute XRRenderState renderState;
   [SameObject] readonly attribute XRSpace viewerSpace;
 
   // Methods


### PR DESCRIPTION
r? @toji

I went to update the spec text to clarify that XRRenderState is a live object, but it's already pretty clear on that it seems. Let me know if I should update something.


Fixes #600