### PR TITLE
Remove gravity mention

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -744,7 +744,7 @@ XRReferenceSpace {#xrreferencespace-interface}
 
 An {{XRReferenceSpace}} is one of several common {{XRSpace}}s that applications can use to establish a spatial relationship with the user's physical environment.
 
-{{XRReferenceSpace}}s are generally expected to remain static for the duration of the {{XRSession}}, with the most common exception being mid-session reconfiguration by the user. The [=native origin=] for every {{XRReferenceSpace}} describes a coordinate system where <code>+X</code> is considered "Right", <code>+Y</code> is considered "Up", and <code>-Z</code> is considered "Forward". All {{XRReferenceSpace}}s except {{XRReferenceSpaceType/identity}} MUST align the Y axis with gravity.
+{{XRReferenceSpace}}s are generally expected to remain static for the duration of the {{XRSession}}, with the most common exception being mid-session reconfiguration by the user. The [=native origin=] for every {{XRReferenceSpace}} describes a coordinate system where <code>+X</code> is considered "Right", <code>+Y</code> is considered "Up", and <code>-Z</code> is considered "Forward".
 
 The base {{XRReferenceSpace}} represents a reference space without any tracking behavior.
 


### PR DESCRIPTION
Brought up by @blairmacintyre in https://github.com/immersive-web/webxr/pull/609#discussion_r279159519

To repeat the concerns there: This makes less sense when in a vehicle, and even less sense in space. It's adequate to define the Y axis as being a deliberately vague notion of "up", since that's more tied to user perception rather than physical concepts. That should be enough to get people to match implementations


(The orientation of the Y axis of natural origins isn't observable if it's consistent across origins anyway, but it's good to avoid overspeccing where unnecessary)

r? @toji