### PR TITLE
Remove non-object [SameObject]s

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1102,7 +1102,7 @@ An {{XRPose}} describes a position and orientation in space relative to an {{XRS
 <pre class="idl">
 [SecureContext, Exposed=Window] interface XRPose {
   [SameObject] readonly attribute XRRigidTransform transform;
-  [SameObject] readonly attribute boolean emulatedPosition;
+  readonly attribute boolean emulatedPosition;
 };
 </pre>
 
@@ -1151,8 +1151,8 @@ enum XRTargetRayMode {
 
 [SecureContext, Exposed=Window]
 interface XRInputSource {
-  [SameObject] readonly attribute XRHandedness handedness;
-  [SameObject] readonly attribute XRTargetRayMode targetRayMode;
+  readonly attribute XRHandedness handedness;
+  readonly attribute XRTargetRayMode targetRayMode;
   [SameObject] readonly attribute XRSpace targetRaySpace;
   [SameObject] readonly attribute XRSpace? gripSpace;
   [SameObject] readonly attribute Gamepad? gamepad;


### PR DESCRIPTION
These are bools and enums which aren't objects, `[SameObject]` will not work on them.

r? @toji