### PR TITLE
Remove redundant "abort these steps" in requestSession() algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -296,7 +296,7 @@ When the <dfn method for="XR">requestSession(|mode|)</dfn> method is invoked, th
   1. [=ensures an XR device is selected|Ensure an XR device is selected=].
   1. If the [=XR/XR device=] is null, [=reject=] |promise| with null.
   1. Else if the [=XR/XR device=]'s [=list of supported modes=] does not [=list/contain=] |mode|, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
-  1. Else If |immersive| is <code>true</code> and the algorithm is not [=triggered by user activation=], [=reject=] |promise| with a "{{SecurityError}}" {{DOMException}} and abort these steps.
+  1. Else if |immersive| is <code>true</code> and the algorithm is not [=triggered by user activation=], [=reject=] |promise| with a "{{SecurityError}}" {{DOMException}}.
   1. If |promise| was [=rejected=] and |immersive| is <code>true</code>, set [=pending immersive session=] to <code>false</code>.
   1. If |promise| was [=rejected=], abort these steps.
   1. Let |session| be a new {{XRSession}} object.


### PR DESCRIPTION
"and abort these steps" is unnecessary as these steps are aborted two steps later. This would also prevent "pending immersive session" from being cleared.