### PR TITLE
Rename getPose arg referenceSpace->baseSpace

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1201,7 +1201,7 @@ An {{XRPose}} describes a position and orientation in space relative to an {{XRS
 };
 </pre>
 
-The <dfn attribute for="XRPose">transform</dfn> attribute describes the position and orientation relative to the reference {{XRSpace}}.
+The <dfn attribute for="XRPose">transform</dfn> attribute describes the position and orientation relative to the base {{XRSpace}}.
 
 <section class="unstable">
 The <dfn attribute for="XRPose">emulatedPosition</dfn> attribute MUST be <code>false</code> if the {{XRPose/transform}}.{{XRRigidTransform/position}} values are based on sensor readings, or <code>true</code> if the position values are software estimations, such as those provided by a neck or arm model.

--- a/index.bs
+++ b/index.bs
@@ -733,7 +733,7 @@ An {{XRFrame}} represents a snapshot of the state of all of the tracked objects 
   [SameObject] readonly attribute XRSession session;
 
   XRViewerPose? getViewerPose(XRReferenceSpace referenceSpace);
-  XRPose? getPose(XRSpace sourceSpace, XRSpace destinationSpace);
+  XRPose? getPose(XRSpace space, XRSpace baseSpace);
 };
 </pre>
 
@@ -766,11 +766,11 @@ When the <dfn method for="XRFrame">getViewerPose(|referenceSpace|)</dfn> method 
 
 <div class="algorithm unstable" data-algorithm="get-pose">
 
-When the <dfn method for="XRFrame">getPose(|space|, |referenceSpace|)</dfn> method is invoked, the user agent MUST run the following steps:
+When the <dfn method for="XRFrame">getPose(|space|, |baseSpace|)</dfn> method is invoked, the user agent MUST run the following steps:
 
   1. Let |frame| be the target {{XRFrame}}
   1. Let |pose| be a new {{XRPose}} object.
-  1. [=Populate the pose=] of |space| in |referenceSpace| at the time represented by |frame| into |pose|.
+  1. [=Populate the pose=] of |space| in |baseSpace| at the time represented by |frame| into |pose|.
   1. Return |pose|.
 
 </div>
@@ -799,16 +799,16 @@ The [=effective origin=] of an {{XRSpace}} can only be observed in the coordinat
 
 <div class="algorithm" data-algorithm="populate-the-pose">
 
-To <dfn>populate the pose</dfn> of a {{XRSpace}} |space| in an  {{XRSpace}} |referenceSpace| at the time represented by a {{XRFrame}} |frame| into an {{XRPose}} |pose|, the user agent MUST run the following steps:
+To <dfn>populate the pose</dfn> of a {{XRSpace}} |space| in an  {{XRSpace}} |baseSpace| at the time represented by a {{XRFrame}} |frame| into an {{XRPose}} |pose|, the user agent MUST run the following steps:
 
   1. 1. If |frame|'s [=active=] boolean is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
   1. Let |session| be |frame|'s {{XRFrame/session}} object.
   1. If |space|'s [=XRSpace/session=] does not equal |session|, throw an {{InvalidStateError}} and abort these steps.
-  1. If |referenceSpace|'s [=XRSpace/session=] does not equal |session|, throw an {{InvalidStateError}} and abort these steps.
-  1. If |referenceSpace|'s pose cannot be determined relative to |space| at the time represented by |frame|, set |pose| to <code>null</code>.
+  1. If |baseSpace|'s [=XRSpace/session=] does not equal |session|, throw an {{InvalidStateError}} and abort these steps.
+  1. If |baseSpace|'s pose cannot be determined relative to |space| at the time represented by |frame|, set |pose| to <code>null</code>.
   1. Let |transform| be |pose|'s {{XRPose/transform}}.
-  1. Set |transform|'s {{XRRigidTransform/position}} to the location of |space|'s [=effective origin=] in |referenceSpace|'s [=coordinate system=].
-  1. Set |transform|'s {{XRRigidTransform/orientation}} to the orientation of |space|'s [=effective origin=] in |referenceSpace|'s [=coordinate system=].
+  1. Set |transform|'s {{XRRigidTransform/position}} to the location of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
+  1. Set |transform|'s {{XRRigidTransform/orientation}} to the orientation of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
 
 </div>
 
@@ -862,12 +862,12 @@ When an {{XRReferenceSpace}} is requested, the user agent MUST <dfn>create a ref
   1. Let |type| be set to the {{XRReferenceSpaceType}} passed to {{requestReferenceSpace()}}.
   1. If the [=reference space is supported=] for |type| and |session|, run the following steps:
     1. Initialize |referenceSpace| based on the following:
-      <dl class="switch">
-        <dt> If |type| is {{bounded-floor}}
-        <dd> Let |referenceSpace| be a new {{XRBoundedReferenceSpace}}.
-        <dt> Otherwise
-        <dd> Let |referenceSpace| be a new {{XRReferenceSpace}}.
-      </dl>
+        <dl class="switch">
+          <dt> If |type| is {{bounded-floor}}
+          <dd> Let |referenceSpace| be a new {{XRBoundedReferenceSpace}}.
+          <dt> Otherwise
+          <dd> Let |referenceSpace| be a new {{XRReferenceSpace}}.
+        </dl>
     1. Initialize |referenceSpace|'s [=XRReferenceSpace/type=] to be |type|.
     1. Initialize |referenceSpace|'s [=XRSpace/session=] to be |session|.
     1. Return |referenceSpace|


### PR DESCRIPTION
Addresses concerns raised after landing #654

The use of `referenceSpace` here may inadvertently suggest that it only
takes an `XRReferenceSpace` object, when in reality it can take any
`XRSpace`. Using `baseSpace` as a replacement at the suggestion of
@klausw and @thetuvix.

Plus it's fun to say: `getPose` finds the place of your space in the
baseSpace's space! 😉 