### PR TITLE
Cleanups on event text

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -255,7 +255,7 @@ Each time the [=list of XR devices=] changes the user agent should <dfn>select a
   1. If this is the first time devices have been enumerated or |oldDevice| equals the [=XR/XR device=], abort these steps.
   1. [=Shut down the session|Shut down=] any active {{XRSession}}s.
   1. Set the [=XR compatible=] boolean of all {{WebGLRenderingContextBase}} instances to `false`.
-  1. [=Queue a task=] that fires a simple event named {{devicechange!!event}} on the [=context object=].
+  1. [=Queue a task=] to fire a simple event named {{devicechange!!event}} on the [=context object=].
 
 </div>
 
@@ -1365,7 +1365,7 @@ Each [=XR input source=] SHOULD define a <dfn>primary action</dfn>. The [=primar
 
 When an [=XR input source=] for {{XRSession}} |session| begins its [=primary action=] the UA MUST run the following steps:
 
-  1. [=Queue a task=] that fires a {{XRInputSourceEvent}} named {{selectstart!!event}} on |session|.
+  1. [=Queue a task=] to fire a {{XRInputSourceEvent}} named {{selectstart!!event}} on |session|.
 
 </div>
 
@@ -1385,7 +1385,7 @@ Sometimes platform-specific behavior can result in a [=primary action=] being in
 
 When an [=XR input source=] for {{XRSession}} |session| has its [=primary action=] cancelled the UA MUST run the following steps:
 
-  1. [=Queue a task=] that fires a {{XRInputSourceEvent}} named {{selectend!!event}} on |session|.
+  1. [=Queue a task=] to fire a {{XRInputSourceEvent}} named {{selectend!!event}} on |session|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -83,6 +83,9 @@ spec: Gamepad; urlPrefix: https://w3c.github.io/gamepad/#
 spec:html; type:method; for:HTMLCanvasElement; text:getContext(contextId); url: https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext
 spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
     type: method; text: IsDetachedBuffer; url: sec-isdetachedbuffer
+spec: dom; urlPrefix: https://dom.spec.whatwg.org/#
+    type:algorithm; text:fire an event; url: concept-event-fire
+
 </pre>
 
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
@@ -255,7 +258,7 @@ Each time the [=list of XR devices=] changes the user agent should <dfn>select a
   1. If this is the first time devices have been enumerated or |oldDevice| equals the [=XR/XR device=], abort these steps.
   1. [=Shut down the session|Shut down=] any active {{XRSession}}s.
   1. Set the [=XR compatible=] boolean of all {{WebGLRenderingContextBase}} instances to `false`.
-  1. [=Queue a task=] to fire a simple event named {{devicechange!!event}} on the [=context object=].
+  1. [=Queue a task=] to [=fire an event=] named {{devicechange!!event}} on the [=context object=].
 
 </div>
 
@@ -1365,7 +1368,7 @@ Each [=XR input source=] SHOULD define a <dfn>primary action</dfn>. The [=primar
 
 When an [=XR input source=] for {{XRSession}} |session| begins its [=primary action=] the UA MUST run the following steps:
 
-  1. [=Queue a task=] to fire a {{XRInputSourceEvent}} named {{selectstart!!event}} on |session|.
+  1. [=Queue a task=] to [=fire an event|fire=] a {{XRInputSourceEvent}} named {{selectstart!!event}} on |session|.
 
 </div>
 
@@ -1385,7 +1388,7 @@ Sometimes platform-specific behavior can result in a [=primary action=] being in
 
 When an [=XR input source=] for {{XRSession}} |session| has its [=primary action=] cancelled the UA MUST run the following steps:
 
-  1. [=Queue a task=] to fire a {{XRInputSourceEvent}} named {{selectend!!event}} on |session|.
+  1. [=Queue a task=] to [=fire an event|fire=] a {{XRInputSourceEvent}} named {{selectend!!event}} on |session|.
 
 </div>
 


### PR DESCRIPTION
Fixes https://github.com/immersive-web/webxr/issues/712

 - Consistently say "Queue a task to fire"
 - Don't say "fire a simple event", just say "fire an event"
 - Link to DOM spec for firing an event

cc @ddorwin