### PR TITLE
Made the xr-standard gamepad mapping more rigid

### DIFF
--- a/images/xr-standard-mapping.svg
+++ b/images/xr-standard-mapping.svg
@@ -15,7 +15,7 @@
    version="1.1"
    id="svg8"
    inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
-   sodipodi:docname="controller.svg">
+   sodipodi:docname="xr-standard-mapping.svg">
   <defs
      id="defs2" />
   <sodipodi:namedview
@@ -25,9 +25,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8"
-     inkscape:cx="381.21983"
-     inkscape:cy="311.364"
+     inkscape:zoom="1.979899"
+     inkscape:cx="399.47711"
+     inkscape:cy="703.73681"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -397,7 +397,7 @@
          x="74.415047"
          y="113.79053"
          style="font-size:4.23333311px;line-height:0.5;text-align:center;text-anchor:middle;stroke-width:0.26458332"
-         id="tspan5165-0-8">(Touchpad Click)</tspan></text>
+         id="tspan5165-0-8">(Touchpad Press)</tspan></text>
     <path
        style="fill:none;stroke:#ff0909;stroke-width:0.46500009;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.93000006, 0.46500004;stroke-dashoffset:0;stroke-opacity:1"
        d="m 33.889438,98.965592 4.881146,7.959928 h 20.312485"
@@ -477,44 +477,44 @@
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:0.5;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="64.945122"
+       x="66.003456"
        y="199.14392"
        id="text5155-1-6-8"><tspan
          sodipodi:role="line"
-         x="64.945122"
+         x="66.003456"
          y="199.14392"
          style="font-size:4.23333311px;line-height:0.5;text-align:center;text-anchor:middle;fill:#2109ff;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
-         id="tspan5161-9-84-1">axes[1]</tspan><tspan
+         id="tspan5161-9-84-1">axes[3]</tspan><tspan
          sodipodi:role="line"
-         x="64.945122"
+         x="66.003456"
          y="204.67264"
          style="font-size:4.23333311px;line-height:0.5;text-align:center;text-anchor:middle;stroke-width:0.26458332"
-         id="tspan5165-0-2-8">(Joystick Y)</tspan></text>
+         id="tspan5165-0-2-8">(Thumbstick Y)</tspan></text>
     <path
        style="fill:none;stroke:#2809ff;stroke-width:0.46500012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.93000007, 0.46500005;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 29.157323,215.3292 13.907715,-17.25414 12.532396,0.13364"
+       d="m 29.157323,215.3292 13.907715,-17.25414 13.467839,0.13364"
        id="path5167-2-8-54"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccc" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:0.5;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="57.86248"
+       x="58.920815"
        y="187.55022"
        id="text5155-1-6-4-6"><tspan
          sodipodi:role="line"
-         x="57.86248"
+         x="58.920815"
          y="187.55022"
          style="font-size:4.23333311px;line-height:0.5;text-align:center;text-anchor:middle;fill:#2109ff;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
-         id="tspan5161-9-84-2-7">axes[0]</tspan><tspan
+         id="tspan5161-9-84-2-7">axes[2]</tspan><tspan
          sodipodi:role="line"
-         x="57.86248"
+         x="58.920815"
          y="193.07893"
          style="font-size:4.23333311px;line-height:0.5;text-align:center;text-anchor:middle;stroke-width:0.26458332"
-         id="tspan5165-0-2-4-0">(Joystick X)</tspan></text>
+         id="tspan5165-0-2-4-0">(Thumbstick X)</tspan></text>
     <path
        style="fill:none;stroke:#2109ff;stroke-width:0.46500012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.93000008, 0.46500005;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 29.157323,215.3292 6.023264,-29.38238 12.828939,0.13363"
+       d="m 29.157323,215.3292 6.023264,-29.38238 14.298921,0.13363"
        id="path5167-2-8-5-3"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccc" />
@@ -528,12 +528,12 @@
          x="76.370033"
          y="210.47946"
          style="font-size:4.23333311px;line-height:0.5;text-align:center;text-anchor:middle;fill:#ff0909;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
-         id="tspan5161-9-8-3">buttons[1]</tspan><tspan
+         id="tspan5161-9-8-3">buttons[3]</tspan><tspan
          sodipodi:role="line"
          x="76.370033"
          y="216.00818"
          style="font-size:4.23333311px;line-height:0.5;text-align:center;text-anchor:middle;stroke-width:0.26458332"
-         id="tspan5361">(Joystick Click)</tspan></text>
+         id="tspan5361">(Thumbstick Press)</tspan></text>
     <path
        style="fill:none;stroke:#ff0909;stroke-width:0.46500012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.93000007, 0.46500005;stroke-dashoffset:0;stroke-opacity:1"
        d="m 29.157323,215.3292 14.24094,-5.91862 h 20.312485"
@@ -688,17 +688,19 @@
          x="103.03984"
          y="283.68451"
          style="font-size:4.23333311px;line-height:0.5;text-align:center;text-anchor:middle;fill:#ff0909;fill-opacity:1;stroke-width:0.26458332"
-         id="tspan5165-0-0-0"><tspan
+         id="tspan1063"><tspan
    style="fill:#000000;fill-opacity:1"
-   id="tspan5533">NOTE: </tspan>buttons[3]<tspan
+   id="tspan5533">NOTE: For this device <tspan
+   style="fill:#0000ff;fill-opacity:1"
+   id="tspan1066">axes[0]</tspan>, <tspan
+   style="fill:#0000ff;fill-opacity:1"
+   id="tspan1078">axes[1]</tspan>, and </tspan>buttons[1]<tspan
    style="fill:#000000;fill-opacity:1"
-   id="tspan5539"> is left empty, since it is reserved</tspan></tspan><tspan
+   id="tspan5539"> are</tspan></tspan><tspan
          sodipodi:role="line"
          x="103.03984"
          y="289.21323"
-         style="font-size:4.23333311px;line-height:0.5;text-align:center;text-anchor:middle;fill:#ff0909;fill-opacity:1;stroke-width:0.26458332"
-         id="tspan5531"><tspan
-           style="fill:#000000;fill-opacity:1"
-           id="tspan5541">for a secondary joystick or touchpad click</tspan></tspan></text>
+         style="font-size:4.23333311px;line-height:0.5;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.26458332"
+         id="tspan5531">placeholders, since they are reserved for Touchpad inputs</tspan></text>
   </g>
 </svg>

--- a/images/xr-standard-mapping.svg
+++ b/images/xr-standard-mapping.svg
@@ -458,7 +458,7 @@
          id="tspan5268"
          x="12.348122"
          y="60.256302"
-         style="font-size:7.05555534px;stroke-width:0.26458332">Simple '<tspan
+         style="font-size:7.05555534px;stroke-width:0.26458332">Example basic '<tspan
    style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:Consolas;-inkscape-font-specification:'Consolas Italic'"
    id="tspan5272">xr-standard'</tspan> controller</tspan></text>
     <text
@@ -471,7 +471,7 @@
          id="tspan5268-1"
          x="12.526529"
          y="177.30522"
-         style="font-size:7.05555534px;stroke-width:0.26458332">Advanced '<tspan
+         style="font-size:7.05555534px;stroke-width:0.26458332">Example complex '<tspan
    style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05555534px;font-family:Consolas;-inkscape-font-specification:'Consolas Italic';stroke-width:0.26458332"
    id="tspan5272-3">xr-standard'</tspan> controller</tspan></text>
     <text

--- a/index.bs
+++ b/index.bs
@@ -1584,13 +1584,13 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} t
     </tr>
     <tr>
       <td>buttons[1]</td>
-      <td>Touchpad Press</td>
-      <td>If thumbstick is not present</td>
+      <td>Secondary Button/Grip Trigger</td>
+      <td>No</td>
     </tr>
     <tr>
       <td>buttons[2]</td>
-      <td>Secondary Button/Grip Trigger</td>
-      <td>No</td>
+      <td>Touchpad Press</td>
+      <td>If thumbstick is not present</td>
     </tr>
     <tr>
       <td>buttons[3]</td>

--- a/index.bs
+++ b/index.bs
@@ -1634,7 +1634,7 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} t
 
 Devices that lack one of the optional inputs listed in the tables above MUST preserve their place in the {{Gamepad/buttons}} or {{Gamepad/axes}} array, reporting a <dfn>placeholder button</dfn> or <dfn>placeholder axis</dfn>, respectively. A [=placeholder button=] MUST report <code>0</code> for {{GamepadButton/value}}, <code>false</code> for {{GamepadButton/pressed}}, and <code>false</code> for {{GamepadButton/touched}}. A [=placeholder axis=] MUST report <code>0</code>. [=Placeholder buttons=] and [=placeholder axis|axes=] MUST be omitted if they are the last element in the array or all following elements are also [=placeholder buttons=] or [=placeholder axis|axes=].
 
-Additional buttons or axes may be exposed after these reserved indices, and SHOULD appear in order of decreasing importance. Related axes (such as both axes of a thumbstick) SHOULD be grouped and, if applicable, SHOULD appear in X, Y, Z order. Buttons reserved by the UA or platform MUST NOT be exposed.
+Additional buttons or axes may be exposed after these reserved indices, and SHOULD appear in order of decreasing importance. Related axes (such as both axes of a thumbstick) MUST be grouped and, if applicable, MUST appear in X, Y, Z order. Buttons reserved by the UA or platform MUST NOT be exposed.
 
 <section class="note">
 <<<<<<< HEAD

--- a/index.bs
+++ b/index.bs
@@ -1551,7 +1551,6 @@ Gamepad API Integration {#gamepad-api-integration}
 ISSUE: <a href="https://github.com/immersive-web/webxr/issues/550">GitHub #550</a> - Additional restrictions, still under discussion, will be applied to the formatting of the {{XRInputSource/gamepad}}'s {{Gamepad/id}} attribute. Until those restrictions have been identified, all {{XRInputSource/gamepad}} {{Gamepad/id}}'s should default to <code>"unknown"</code>.
 </section>
 
-<section class="unstable">
 "xr-standard" Gamepad Mapping {#xr-standard-gamepad-mapping}
 -----------------------------
 
@@ -1567,13 +1566,13 @@ The WebXR Device API extends the {{GamepadMappingType}} to describe the mapping 
 
 The <dfn enum-value for="GamepadMappingType">xr-standard</dfn> mapping indicates that the layout of the buttons and axes of the {{XRInputSource/gamepad}} corresponds as closely as possible to the tables below.
 
-In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} the device MUST report an {{XRInputSource/targetRayMode}} of {{XRTargetRayMode/tracked-pointer}} and MUST have a non-<code>null</code> {{XRInputSource/gripSpace}}. It also MUST have at least one touchpad or joystick and MUST have at least one primary button, often a trigger, separate from the touchpad or joystick. If a device does not meet the requirements for the {{GamepadMappingType/xr-standard}} mapping it may still be exposed on an {{XRInputSource}} with the <code>""</code> (empty string) mapping. The {{GamepadMappingType/xr-standard}} mapping MUST only be used by {{Gamepad}} instances reported by an {{XRInputSource}}.
+In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} the device MUST report an {{XRInputSource/targetRayMode}} of {{XRTargetRayMode/tracked-pointer}} and MUST have a non-<code>null</code> {{XRInputSource/gripSpace}}. It also MUST have at least one touchpad or thumbstick and MUST have at least one primary button, often a trigger, separate from the touchpad or thumbstick. If a device does not meet the requirements for the {{GamepadMappingType/xr-standard}} mapping it may still be exposed on an {{XRInputSource}} with the <code>""</code> (empty string) mapping. The {{GamepadMappingType/xr-standard}} mapping MUST only be used by {{Gamepad}} instances reported by an {{XRInputSource}}.
 
 <table class="tg">
   <thead>
     <tr>
       <th>Buttons</th>
-      <th><code>xr-standard</code> Location</th>
+      <th><code>xr-standard</code> Binding</th>
       <th>Required</th>
     </tr>
   </thead>
@@ -1585,8 +1584,8 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} t
     </tr>
     <tr>
       <td>buttons[1]</td>
-      <td>Primary Touchpad/Joystick Button</td>
-      <td>Yes</td>
+      <td>Touchpad Press</td>
+      <td>If thumbstick is not present</td>
     </tr>
     <tr>
       <td>buttons[2]</td>
@@ -1595,8 +1594,8 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} t
     </tr>
     <tr>
       <td>buttons[3]</td>
-      <td>Secondary Touchpad/Joystick Button</td>
-      <td>No</td>
+      <td>Thumbstick Press</td>
+      <td>If touchpad is not present</td>
     </tr>
   </tbody>
 </table>
@@ -1605,39 +1604,40 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} t
   <thead>
     <tr>
       <th>Axes</th>
-      <th><code>xr-standard</code> Location</th>
+      <th><code>xr-standard</code> Binding</th>
       <th>Required</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>axes[0]</td>
-      <td>Primary Touchpad/Joystick X</td>
-      <td>Yes</td>
+      <td>Touchpad X</td>
+      <td>If thumbstick is not present</td>
     </tr>
     <tr>
       <td>axes[1]</td>
-      <td>Primary Touchpad/Joystick Y</td>
-      <td>Yes</td>
+      <td>Touchpad Y</td>
+      <td>If thumbstick is not present</td>
     </tr>
     <tr>
       <td>axes[2]</td>
-      <td>Secondary Touchpad/Joystick X</td>
-      <td>No</td>
+      <td>Thumbstick X</td>
+      <td>If touchpad is not present</td>
     </tr>
     <tr>
       <td>axes[3]</td>
-      <td>Secondary Touchpad/Joystick Y</td>
-      <td>No</td>
+      <td>Thumbstick Y</td>
+      <td>If touchpad is not present</td>
     </tr>
   </tbody>
 </table>
 
 Devices that lack one of the optional inputs listed in the tables above MUST preserve their place in the {{Gamepad/buttons}} or {{Gamepad/axes}} array, reporting a <dfn>placeholder button</dfn> or <dfn>placeholder axis</dfn>, respectively. A [=placeholder button=] MUST report <code>0</code> for {{GamepadButton/value}}, <code>false</code> for {{GamepadButton/pressed}}, and <code>false</code> for {{GamepadButton/touched}}. A [=placeholder axis=] MUST report <code>0</code>. [=Placeholder buttons=] and [=placeholder axis|axes=] MUST be omitted if they are the last element in the array or all following elements are also [=placeholder buttons=] or [=placeholder axis|axes=].
 
-Additional buttons or axes may be exposed after these reserved indices, and SHOULD appear in order of decreasing importance. Related axes (such both axes of a joystick) SHOULD be grouped and, if applicable, SHOULD appear in X, Y, Z order. If a device has both a touchpad and a joystick the UA MAY designate whichever it chooses to be the primary axis-based input. Buttons reserved by the UA or platform MUST NOT be exposed.
+Additional buttons or axes may be exposed after these reserved indices, and SHOULD appear in order of decreasing importance. Related axes (such both axes of a thumbstick) SHOULD be grouped and, if applicable, SHOULD appear in X, Y, Z order. Buttons reserved by the UA or platform MUST NOT be exposed.
 
-NOTE: This diagram demonstrates how two potential controllers would be exposed with the {{GamepadMappingType/xr-standard}} mapping. <img src="images/xr-standard-mapping.svg" alt="Simple 'xr-standard' controller and Advanced 'xr-standard' controller">
+<section class="note">
+This diagram demonstrates how two potential controllers would be exposed with the {{GamepadMappingType/xr-standard}} mapping. <img src="images/xr-standard-mapping.svg" alt="Simple 'xr-standard' controller and Advanced 'xr-standard' controller">
 </section>
 
 Layers {#layers}

--- a/index.bs
+++ b/index.bs
@@ -1566,7 +1566,7 @@ The WebXR Device API extends the {{GamepadMappingType}} to describe the mapping 
 
 The <dfn enum-value for="GamepadMappingType">xr-standard</dfn> mapping indicates that the layout of the buttons and axes of the {{XRInputSource/gamepad}} corresponds as closely as possible to the tables below.
 
-In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} the device MUST report an {{XRInputSource/targetRayMode}} of {{XRTargetRayMode/tracked-pointer}} and MUST have a non-<code>null</code> {{XRInputSource/gripSpace}}. It also MUST have at least one touchpad or thumbstick and MUST have at least one primary button, often a trigger, separate from the touchpad or thumbstick. If a device does not meet the requirements for the {{GamepadMappingType/xr-standard}} mapping it may still expose a {{XRInputSource/gamepad}} with a {{Gamepad/mapping}} of <code>""</code> (empty string). The {{GamepadMappingType/xr-standard}} mapping MUST only be used by {{Gamepad}} instances reported by an {{XRInputSource}}.
+In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} the device MUST report an {{XRInputSource/targetRayMode}} of {{XRTargetRayMode/tracked-pointer}} and MUST have a non-<code>null</code> {{XRInputSource/gripSpace}}. It MUST have at least one primary button, often a trigger, separate from any touchpads or thumbsticks. If a device does not meet the requirements for the {{GamepadMappingType/xr-standard}} mapping it may still expose a {{XRInputSource/gamepad}} with a {{Gamepad/mapping}} of <code>""</code> (empty string). The {{GamepadMappingType/xr-standard}} mapping MUST only be used by {{Gamepad}} instances reported by an {{XRInputSource}}.
 
 <table class="tg">
   <thead>
@@ -1590,12 +1590,12 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} t
     <tr>
       <td>buttons[2]</td>
       <td>Touchpad Press</td>
-      <td>If thumbstick is not present</td>
+      <td>No</td>
     </tr>
     <tr>
       <td>buttons[3]</td>
       <td>Thumbstick Press</td>
-      <td>If touchpad is not present</td>
+      <td>No</td>
     </tr>
   </tbody>
 </table>
@@ -1612,22 +1612,22 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} t
     <tr>
       <td>axes[0]</td>
       <td>Touchpad X</td>
-      <td>If thumbstick is not present</td>
+      <td>No</td>
     </tr>
     <tr>
       <td>axes[1]</td>
       <td>Touchpad Y</td>
-      <td>If thumbstick is not present</td>
+      <td>No</td>
     </tr>
     <tr>
       <td>axes[2]</td>
       <td>Thumbstick X</td>
-      <td>If touchpad is not present</td>
+      <td>No</td>
     </tr>
     <tr>
       <td>axes[3]</td>
       <td>Thumbstick Y</td>
-      <td>If touchpad is not present</td>
+      <td>No</td>
     </tr>
   </tbody>
 </table>
@@ -2039,7 +2039,7 @@ A user agent MUST dispatch a <dfn event for="XRSession">select</dfn> event on an
 
 A user agent MUST dispatch a <dfn event for="XRReferenceSpace">reset</dfn> event on an {{XRReferenceSpace}} when discontinuities of the [=native origin=] or [=effective origin=] occur, i.e. there are significant changes in the origin’s position or orientation relative to the user’s environment. (For example: After user recalibration of their XR device or if the XR device automatically shifts its origin after losing and regaining tracking.) A {{reset}} event MUST also be dispatched when the {{boundsGeometry}} changes for an {{XRBoundedReferenceSpace}}. A {{reset}} event MUST NOT be dispatched if the [=viewer=]'s pose experiences discontinuities but the {{XRReferenceSpace}}'s origin physical mapping remains stable, such as when the [=viewer=] momentarily loses and regains tracking within the same tracking area. A {{reset}} event also MUST NOT be dispatched as an {{unbounded}} reference space makes small adjustments to its [=native origin=] over time to maintain space stability near the user, if a significant discontinuity has not occurred. The event MUST be of type {{XRReferenceSpaceEvent}}, and MUST be dispatched prior to the execution of any [=XR animation frame=]s that make use of the new origin.
 
-NOTE: Jumps in [=viewer=] position can be handled by the application by observing the {{XRPose/emulatedPosition}} boolean. If a jump in [=viewer=] position coincides with {{XRPose/emulatedPosition}} switching from <code>true</code> to <code>false</code>, it indicates that the [=viewer=] has regained tracking and their new position represents a correction from the previously emulated values. For experiences without a "teleportation" mechanic, where the [=viewer=] can move through the virtual world without moving physically, this is generally the application's desired behavior. However, if an experience does provide a "teleportation" mechanic, it may be needlessly jarring to jump the [=viewer=]'s position back after tracking recovery. Instead, when such an application recovers tracking, it can simply resume the experience from the [=viewer=]'s current position in the virtual world by absorbing that sudden jump in position into its teleportation offset. To do so, the developer calls {{getOffsetReferenceSpace()}} to create a replacement reference space with its |originOffset| adjusted by the amount that the [=viewer=]'s position jumped since the previous frame.
+NOTE: Jumps in [=viewer=] position can be handled by the application by observing the {{XRPose/emulatedPosition}} boolean. If a jump in [=viewer=] position coincides with {{XRPose/emulatedPosition}} switching from <code>true</code> to <code>false</code>, it indicates that the [=viewer=] has regained tracking and their new position represents a correction from the previously emulated values. For experiences without a "teleportation" mechanic, where the [=viewer=] can move through the virtual world without moving physically, this is generally the application's desired behavior. However, if an experience does provide a "teleportation" mechanic, it may be needlessly jarring to jump the [=viewer=]'s position back after tracking recovery. Instead, when such an application recovers tracking, it can simply resume the experience from the [=viewer=]'s current position in the virtual world by absorbing that sudden jump in position into its teleportation offset. To do so, the developer calls {{getOffsetReferenceSpace()}} to create a replacement reference space with its [=effective origin=] adjusted by the amount that the [=viewer=]'s position jumped since the previous frame.
 
 Security, Privacy, and Comfort Considerations {#security}
 =============================================

--- a/index.bs
+++ b/index.bs
@@ -1572,7 +1572,7 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} t
   <thead>
     <tr>
       <th>Buttons</th>
-      <th><code>xr-standard</code> Binding</th>
+      <th><code>xr-standard</code> Mapping</th>
       <th>Required</th>
     </tr>
   </thead>
@@ -1604,7 +1604,7 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} t
   <thead>
     <tr>
       <th>Axes</th>
-      <th><code>xr-standard</code> Binding</th>
+      <th><code>xr-standard</code> Mapping</th>
       <th>Required</th>
     </tr>
   </thead>

--- a/index.bs
+++ b/index.bs
@@ -1637,11 +1637,7 @@ Devices that lack one of the optional inputs listed in the tables above MUST pre
 Additional buttons or axes may be exposed after these reserved indices, and SHOULD appear in order of decreasing importance. Related axes (such as both axes of a thumbstick) MUST be grouped and, if applicable, MUST appear in X, Y, Z order. Buttons reserved by the UA or platform MUST NOT be exposed.
 
 <section class="note">
-<<<<<<< HEAD
-This diagram demonstrates how two potential controllers would be exposed with the {{GamepadMappingType/xr-standard}} mapping. <img src="images/xr-standard-mapping.svg" alt="Simple 'xr-standard' controller and Advanced 'xr-standard' controller">
-=======
 This diagram demonstrates how two example controllers would be exposed with the {{GamepadMappingType/xr-standard}} mapping. Images are not intended to represent any particular device and are used for reference purposes only. <img src="images/xr-standard-mapping.svg" alt="Simple 'xr-standard' controller and Advanced 'xr-standard' controller">
->>>>>>> Addressed Nell's feedback
 </section>
 
 Layers {#layers}

--- a/index.bs
+++ b/index.bs
@@ -1566,7 +1566,7 @@ The WebXR Device API extends the {{GamepadMappingType}} to describe the mapping 
 
 The <dfn enum-value for="GamepadMappingType">xr-standard</dfn> mapping indicates that the layout of the buttons and axes of the {{XRInputSource/gamepad}} corresponds as closely as possible to the tables below.
 
-In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} the device MUST report an {{XRInputSource/targetRayMode}} of {{XRTargetRayMode/tracked-pointer}} and MUST have a non-<code>null</code> {{XRInputSource/gripSpace}}. It also MUST have at least one touchpad or thumbstick and MUST have at least one primary button, often a trigger, separate from the touchpad or thumbstick. If a device does not meet the requirements for the {{GamepadMappingType/xr-standard}} mapping it may still be exposed on an {{XRInputSource}} with the <code>""</code> (empty string) mapping. The {{GamepadMappingType/xr-standard}} mapping MUST only be used by {{Gamepad}} instances reported by an {{XRInputSource}}.
+In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} the device MUST report an {{XRInputSource/targetRayMode}} of {{XRTargetRayMode/tracked-pointer}} and MUST have a non-<code>null</code> {{XRInputSource/gripSpace}}. It also MUST have at least one touchpad or thumbstick and MUST have at least one primary button, often a trigger, separate from the touchpad or thumbstick. If a device does not meet the requirements for the {{GamepadMappingType/xr-standard}} mapping it may still expose a {{XRInputSource/gamepad}} with a {{Gamepad/mapping}} of <code>""</code> (empty string). The {{GamepadMappingType/xr-standard}} mapping MUST only be used by {{Gamepad}} instances reported by an {{XRInputSource}}.
 
 <table class="tg">
   <thead>
@@ -1634,10 +1634,14 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/xr-standard}} t
 
 Devices that lack one of the optional inputs listed in the tables above MUST preserve their place in the {{Gamepad/buttons}} or {{Gamepad/axes}} array, reporting a <dfn>placeholder button</dfn> or <dfn>placeholder axis</dfn>, respectively. A [=placeholder button=] MUST report <code>0</code> for {{GamepadButton/value}}, <code>false</code> for {{GamepadButton/pressed}}, and <code>false</code> for {{GamepadButton/touched}}. A [=placeholder axis=] MUST report <code>0</code>. [=Placeholder buttons=] and [=placeholder axis|axes=] MUST be omitted if they are the last element in the array or all following elements are also [=placeholder buttons=] or [=placeholder axis|axes=].
 
-Additional buttons or axes may be exposed after these reserved indices, and SHOULD appear in order of decreasing importance. Related axes (such both axes of a thumbstick) SHOULD be grouped and, if applicable, SHOULD appear in X, Y, Z order. Buttons reserved by the UA or platform MUST NOT be exposed.
+Additional buttons or axes may be exposed after these reserved indices, and SHOULD appear in order of decreasing importance. Related axes (such as both axes of a thumbstick) SHOULD be grouped and, if applicable, SHOULD appear in X, Y, Z order. Buttons reserved by the UA or platform MUST NOT be exposed.
 
 <section class="note">
+<<<<<<< HEAD
 This diagram demonstrates how two potential controllers would be exposed with the {{GamepadMappingType/xr-standard}} mapping. <img src="images/xr-standard-mapping.svg" alt="Simple 'xr-standard' controller and Advanced 'xr-standard' controller">
+=======
+This diagram demonstrates how two example controllers would be exposed with the {{GamepadMappingType/xr-standard}} mapping. Images are not intended to represent any particular device and are used for reference purposes only. <img src="images/xr-standard-mapping.svg" alt="Simple 'xr-standard' controller and Advanced 'xr-standard' controller">
+>>>>>>> Addressed Nell's feedback
 </section>
 
 Layers {#layers}

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -313,7 +313,7 @@ function onXRFrame(timestamp, frame) {
   if (inputSource && inputSource.gamepad) {
     let gamepad = inputSource.gamepad;
     
-    // Use joystick or touchpad values for movement.
+    // Use touchpad values for movement.
     if (gamepad.axes.length >= 2) {
       MoveUser(gamepad.axes[0], gamepad.axes[1]);
     }
@@ -336,29 +336,29 @@ The UA may update the `gamepad` state at any point, but it must remain constant 
 
 ### XR gamepad mapping
 
-The WebXR Device API also introduces a new standard controller layout indicated by the `mapping` value of `xr-standard`. (Additional mapping variants may be added in the future if necessary.) This defines a specific layout for the inputs most commonly found on XR controller devices today. The following table describes the buttons/axes and their physical locations:
+The WebXR Device API also introduces a new standard controller layout indicated by the `mapping` value of `xr-standard`. (Additional mapping variants may be added in the future if necessary.) This defines a specific layout for the inputs most commonly found on XR controller devices today. The following table describes the buttons/axes and their associated physical inputs:
 
-| Button     | `xr-standard` Location            |
-| ---------- | --------------------------------- |
-| buttons[0] | Primary trigger                   |
-| buttons[1] | Primary Touchpad/Joystick click   |
-| buttons[2] | Grip/Secondary trigger            |
-| buttons[3] | Secondary Touchpad/Joystick click |
+| Button     | `xr-standard` Binding  |
+| ---------- | -----------------------|
+| buttons[0] | Primary trigger        |
+| buttons[1] | Touchpad press         |
+| buttons[2] | Grip/Secondary trigger |
+| buttons[3] | Thumbstick press       |
 
-| Axis    | `xr-standard` Location        |
-| ------- | ----------------------------- |
-| axes[0] | Primary Touchpad/Joystick X   |
-| axes[1] | Primary Touchpad/Joystick Y   |
-| axes[2] | Secondary Touchpad/Joystick X |
-| axes[3] | Secondary Touchpad/Joystick Y |
+| Axis    | `xr-standard` Binding |
+| ------- | ----------------------|
+| axes[0] | Touchpad X            |
+| axes[1] | Touchpad Y            |
+| axes[2] | Thumbstick X          |
+| axes[3] | Thumbstick Y          |
 
-Additional device-specific inputs may be exposed after these reserved indices, but devices that lack one of the canonical inputs must still preserve their place in the array. If a device has both a touchpad and a joystick the UA should designate one of them to be the primary axis-based input and expose the other at axes[2] and axes[3] with an associated button at button[3].
+Additional device-specific inputs may be exposed after these reserved indices, but devices that lack one of the canonical inputs must still preserve their place in the array.
 
 In order to make use of the `xr-standard` mapping, a device must meet **at least** the following criteria:
 
  - Is a `tracked-pointer` device. 
  - Has a trigger or similarly accessed button
- - Has at least one touchpad or joystick
+ - Has at least one touchpad or thumbstick
 
 devices that lack one of those elements may still expose `gamepad` data, but must not claim the `xr-standard` mapping. For example: The controls on the side of a Gear VR would not qualify for the `xr-standard` mapping because they represent a `gaze`-style input. Similarly, a Daydream controller would not qualify for the `xr-standard` mapping since it lacks a trigger.
 
@@ -368,13 +368,16 @@ Some native APIs rely on what's commonly referred to as an "action mapping" syst
 
 When using an API that limits reading controller input to use of an action map, it is suggested that a mapping be created with one action per possible input, given the same name as the target input. For example, an similar mapping to the following may be used for each device:
 
-| Button/Axis | Action name      | Sample binding            |
-|-------------|------------------|---------------------------|
-| button[0]   | "trigger"        | "[device]/trigger"        |
-| button[1]   | "touchpad-click" | "[device]/touchpad/click" |
-| button[2]   | "grip"           | "[device]/grip"           |
-| axis[0]     | "touchpad-x"     | "[device]/touchpad/x"     |
-| axis[1]     | "touchpad-y"     | "[device]/touchpad/y"     |
+| Button/Axis | Action name        | Sample binding              |
+|-------------|--------------------|-----------------------------|
+| button[0]   | "trigger"          | "[device]/trigger"          |
+| button[1]   | "touchpad-click"   | "[device]/touchpad/click"   |
+| button[2]   | "grip"             | "[device]/grip"             |
+| button[3]   | "thumbstick-click" | "[device]/thumbstick/click" |
+| axis[0]     | "touchpad-x"       | "[device]/touchpad/x"       |
+| axis[1]     | "touchpad-y"       | "[device]/touchpad/y"       |
+| axis[2]     | "thumbstick-x"     | "[device]/thumbstick/x"     |
+| axis[3]     | "thumbstick-y"     | "[device]/thumbstick/y"     |
 
 If the API does not provided a way to enumerate the available input devices, the UA should provide bindings for the left and right hand instead of a specific device and expose a `Gamepad` for any hand that has at least one non-`null` input.
 

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -341,8 +341,8 @@ The WebXR Device API also introduces a new standard controller layout indicated 
 | Button     | `xr-standard` Binding  |
 | ---------- | -----------------------|
 | buttons[0] | Primary trigger        |
-| buttons[1] | Touchpad press         |
-| buttons[2] | Grip/Secondary trigger |
+| buttons[1] | Grip/Secondary trigger |
+| buttons[2] | Touchpad press         |
 | buttons[3] | Thumbstick press       |
 
 | Axis    | `xr-standard` Binding |
@@ -371,8 +371,8 @@ When using an API that limits reading controller input to use of an action map, 
 | Button/Axis | Action name        | Sample binding              |
 |-------------|--------------------|-----------------------------|
 | button[0]   | "trigger"          | "[device]/trigger"          |
-| button[1]   | "touchpad-click"   | "[device]/touchpad/click"   |
-| button[2]   | "grip"             | "[device]/grip"             |
+| button[1]   | "grip"             | "[device]/grip"             |
+| button[2]   | "touchpad-click"   | "[device]/touchpad/click"   |
 | button[3]   | "thumbstick-click" | "[device]/thumbstick/click" |
 | axis[0]     | "touchpad-x"       | "[device]/touchpad/x"       |
 | axis[1]     | "touchpad-y"       | "[device]/touchpad/y"       |

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -338,14 +338,14 @@ The UA may update the `gamepad` state at any point, but it must remain constant 
 
 The WebXR Device API also introduces a new standard controller layout indicated by the `mapping` value of `xr-standard`. (Additional mapping variants may be added in the future if necessary.) This defines a specific layout for the inputs most commonly found on XR controller devices today. The following table describes the buttons/axes and their associated physical inputs:
 
-| Button     | `xr-standard` Binding  |
-| ---------- | -----------------------|
-| buttons[0] | Primary trigger        |
-| buttons[1] | Grip/Secondary trigger |
-| buttons[2] | Touchpad press         |
-| buttons[3] | Thumbstick press       |
+| Button     | `xr-standard` Mapping    |
+| ---------- | -------------------------|
+| buttons[0] | Primary button/trigger   |
+| buttons[1] | Secondary button/trigger |
+| buttons[2] | Touchpad press           |
+| buttons[3] | Thumbstick press         |
 
-| Axis    | `xr-standard` Binding |
+| Axis    | `xr-standard` Mapping |
 | ------- | ----------------------|
 | axes[0] | Touchpad X            |
 | axes[1] | Touchpad Y            |

--- a/input-explainer.md
+++ b/input-explainer.md
@@ -357,10 +357,9 @@ Additional device-specific inputs may be exposed after these reserved indices, b
 In order to make use of the `xr-standard` mapping, a device must meet **at least** the following criteria:
 
  - Is a `tracked-pointer` device. 
- - Has a trigger or similarly accessed button
- - Has at least one touchpad or thumbstick
+ - Has a trigger or similarly accessed button separate from any touchpads or thumbsticks
 
-devices that lack one of those elements may still expose `gamepad` data, but must not claim the `xr-standard` mapping. For example: The controls on the side of a Gear VR would not qualify for the `xr-standard` mapping because they represent a `gaze`-style input. Similarly, a Daydream controller would not qualify for the `xr-standard` mapping since it lacks a trigger.
+devices that do not meet that criteria may still expose `gamepad` data, but must not claim the `xr-standard` mapping. For example: The controls on the side of a Gear VR would not qualify for the `xr-standard` mapping because they represent a `gaze`-style input. Similarly, a Daydream controller would not qualify for the `xr-standard` mapping since it lacks a trigger.
 
 ### Exposing button/axis values with action maps
 


### PR DESCRIPTION
Addresses concerns brought up in #695 

This will make cross-platform implementations more compatible by
removing some level of platform option from the mapping process. It will
also make it more practical to expose the discussed "profiles" concept
by making it easier to have inter-compatible sets of profiles.

Also took the opportunity to normalized on the verbiage "thumbstick"
instead of joystick, since that appears to be the official verbiage used
by all the device vendors.