### PR TITLE
Remove the Unstable banner from the top of the spec.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -18,13 +18,6 @@ Editor: Brandon Jones 87824, Google http://google.com/, bajones@google.com
 Editor: Nell Waliczek 93109, Amazon [Microsoft until 2018] https://amazon.com/, nhw@amazon.com
 
 Abstract: This specification describes support for accessing virtual reality (VR) and augmented reality (AR) devices, including sensors and head-mounted displays, on the Web.
-
-Warning: custom
-Custom Warning Title: Unstable API
-Custom Warning Text:
-  <b>Parts of the API represented in this document are incomplete and may change at any time.</b>
-  <p>For additional context on the use of this API please reference the <a href="https://github.com/immersive-web/webxr/blob/master/explainer.md">WebXR Device API Explainer</a>.</p>
-
 </pre>
 
 <pre class="link-defaults">


### PR DESCRIPTION
/fixes #672 

**Do not merge until the [June milestone](https://github.com/immersive-web/webxr/milestone/9) is complete**
(I mostly just want the related issue to stop showing up in the [non-pending list](https://github.com/immersive-web/webxr/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+milestone%3A%22June+2019%22+-label%3A%22fixed+by+pending+PR%22))