### PR TITLE
Disallow stereo inline sessions for now

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -371,7 +371,7 @@ enum XRSessionMode {
 };
 </pre>
 
-  - A session mode of <dfn enum-value for="XRSessionMode">inline</dfn> indicates that the session's output will be shown as an element in the HTML document. {{inline}} session content MAY be displayed in mono or stereo and MAY allow for [=viewer=] tracking. User agents MUST allow {{inline}} sessions to be created.
+  - A session mode of <dfn enum-value for="XRSessionMode">inline</dfn> indicates that the session's output will be shown as an element in the HTML document. {{inline}} session content MUST be displayed in mono (i.e., with a single [=view=]). It MAY allow for [=viewer=] tracking. User agents MUST allow {{inline}} sessions to be created.
   - A session mode of <dfn enum-value for="XRSessionMode">immersive-vr</dfn> indicates that the session's output will be given [=exclusive access=] to the [=XR/immersive XR device=] display and that content <b>is not</b> intended to be integrated with the user's environment.
 
 In this document, the term <dfn>inline session</dfn> is synonymous with an {{inline}} session and the term <dfn>immersive session</dfn> is synonymous with an {{immersive-vr}} session.


### PR DESCRIPTION
With https://github.com/immersive-web/webxr/issues/636 stereo inline sessions aren't possible anymore since you need a separate presentation context (or at least a separate framebuffer) to make that work. This PR removes some of the older text allowing stereo inline sessions.

In the future we may add diorama support (see https://github.com/immersive-web/webxr/issues/756, https://github.com/immersive-web/proposals/issues/31), but for now the spec shouldn't allow a thing that it renders impossible anyway.

r? @NellWaliczek