### PR TITLE
Specified that XRWebGLLayer framebuffers always use premultiplied alpha

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1684,6 +1684,7 @@ An <dfn>opaque framebuffer</dfn> functions identically to a standard {{WebGLFram
  - An [=opaque framebuffer=] initialized with {{XRWebGLLayerInit/depth}} <code>false</code> will not have an attached depth buffer.
  - An [=opaque framebuffer=] initialized with {{XRWebGLLayerInit/stencil}} <code>false</code> will not have an attached stencil buffer.
  - An [=opaque framebuffer=]'s color buffer will have an alpha channel if and only if {{XRWebGLLayerInit/alpha}} is <code>true</code>.
+ - The [=XR Compositor=] will assume the [=opaque framebuffer=] contains colors with premultiplied alpha. This is true regardless of the {{WebGLContextAttributes|premultipliedAlpha}} value set in the {{XRWebGLLayer/context}}'s [=actual context parameters=].
 
 NOTE: User agents are not required to respect <code>true</code> values of {{XRWebGLLayerInit/depth}} and {{XRWebGLLayerInit/stencil}}, which is similar to WebGL's behavior when [=create a drawing buffer|creating a drawing buffer=]
 


### PR DESCRIPTION
Not intended for merge until discussed at TPAC /facetoface

Would fix #837 and #838 if the working group's decision is that `XRWebGLLayer`s are always treated as using premultiplied alpha regardless of the source context's flags. Preparing this for easy approval should that be the case.