### PR TITLE
Add a table of contents to the explainers

### DIFF
--- a/input-explainer.md
+++ b/input-explainer.md
@@ -1,6 +1,35 @@
 # WebXR Device API - Input
 This document explains the portion of the WebXR APIs for managing input across the range of XR hardware. For context, it may be helpful to have first read about [WebXR Session Establishment](explainer.md) and [Spatial Tracking](spatial-tracking-explainer.md).
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Contents
+
+- [Concepts](#concepts)
+  - [Targeting categories](#targeting-categories)
+    - [Gaze](#gaze)
+    - [Tracked Pointer](#tracked-pointer)
+    - [Screen](#screen)
+  - [Selection styles](#selection-styles)
+- [Basic usage](#basic-usage)
+  - [Enumerating input sources](#enumerating-input-sources)
+  - [Targeting ray pose](#targeting-ray-pose)
+- [Input events](#input-events)
+  - [Transient input sources](#transient-input-sources)
+  - [Choosing a preferred input source](#choosing-a-preferred-input-source)
+- [Rendering Input](#rendering-input)
+  - [Visualizing targeting hints](#visualizing-targeting-hints)
+    - [Cursors](#cursors)
+    - [Highlights](#highlights)
+    - [Pointing rays](#pointing-rays)
+  - [Renderable models](#renderable-models)
+    - [Choosing renderable models](#choosing-renderable-models)
+    - [Placing renderable models](#placing-renderable-models)
+  - [Generic Profiles](#generic-profiles)
+- [Appendix A: Proposed partial IDL](#appendix-a-proposed-partial-idl)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Concepts
 In addition to the diversity of tracking and display technology, XR hardware may support a wide variety of input mechanisms including screen taps, motion controllers (with multiple buttons, joysticks, triggers, touchpads, etc), voice commands, spatially-tracked articulated hands, single button clickers, and more. Despite this variation, all XR input mechanisms have a common purpose: enabling users to aim in 3D space and perform an action on the target of that aim. This concept is known as "target and select" and is the foundation for how input is exposed in WebXR.
 

--- a/package.json
+++ b/package.json
@@ -3,14 +3,16 @@
   "description": "WebXR Device API Specification",
   "version": "0.0.1",
   "devDependencies": {
-    "browser-sync": "^2.18.8"
+    "browser-sync": "^2.18.8",
+    "doctoc": "^1.4.0"
   },
   "scripts": {
     "start": "npm run dev",
     "dev": "cross-env NODE_ENV=development npm run server",
     "prod": "cross-env NODE_ENV=production npm run server",
     "server": "browser-sync start --config scripts/browsersync-config.js",
-    "build": "make"
+    "build": "make",
+    "doctoc": "doctoc --title '## Contents' explainer.md input-explainer.md privacy-security-explainer.md spatial-tracking-explainer.md"
   },
   "dependencies": {
     "cross-env": "^4.0.0"

--- a/privacy-security-explainer.md
+++ b/privacy-security-explainer.md
@@ -2,6 +2,46 @@
 
 The WebXR Device API enables developers to build content for AR and VR hardware that uses one or more sensors to infer information about the real world, and may then present information about the real world either to developers or directly to the end user. In such systems there are a wide range of input sensor types used (cameras, accelerometers, etc), and a variety of real-world data generated. This data is what allows web developers to author WebXR-based experiences. It also enables developers to infer information about users such as profiling them, fingerprinting their device, and input sniffing. Due to the nature of the Web, WebXR has a higher responsibility to protect users from malicious data usage than XR experiences delivered through closed ecosystem app stores.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Contents
+
+  - [Concepts](#concepts)
+    - [Sensitive information](#sensitive-information)
+    - [Device Fingerprinting](#device-fingerprinting)
+    - [User Profiling](#user-profiling)
+    - [Private Browsing modes](#private-browsing-modes)
+- [Protection types](#protection-types)
+  - [Trustworthy documents and origins](#trustworthy-documents-and-origins)
+    - [Focus and visibility](#focus-and-visibility)
+    - [Feature policy](#feature-policy)
+      - [Underlying sensors feature policy](#underlying-sensors-feature-policy)
+  - [Trusted UI](#trusted-ui)
+  - [User intention](#user-intention)
+    - [User activation](#user-activation)
+    - [Implied consent](#implied-consent)
+    - [Explicit consent](#explicit-consent)
+    - [Duration of consent](#duration-of-consent)
+    - [Querying consent status](#querying-consent-status)
+  - [Data adjustments](#data-adjustments)
+    - [Throttling](#throttling)
+    - [Rounding, quantization, and fuzzing](#rounding-quantization-and-fuzzing)
+    - [Limiting](#limiting)
+- [Protected functionality](#protected-functionality)
+  - [Immersiveness](#immersiveness)
+  - [Poses](#poses)
+    - [XRPose](#xrpose)
+    - [XRViewerPose](#xrviewerpose)
+  - [Reference spaces](#reference-spaces)
+    - [Unbounded reference spaces](#unbounded-reference-spaces)
+    - [Bounded reference spaces](#bounded-reference-spaces)
+    - [Local-floor spaces](#local-floor-spaces)
+    - [Local reference spaces](#local-reference-spaces)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Concepts
+
 ### Sensitive information
 In the context of XR, sensitive information includes, but is not limited to, user configurable data such as interpupillary distance (IPD) and sensor-based data such as poses. All `immersive` sessions will expose some amount of sensitive data, due to the user's pose being necessary to render anything. However, in some cases, the same sensitive information will also be exposed via `inline` sessions.
 

--- a/spatial-tracking-explainer.md
+++ b/spatial-tracking-explainer.md
@@ -1,6 +1,42 @@
 # WebXR Device API - Spatial Tracking
 This document explains the technology and portion of the WebXR APIs used to track users' movement for a stable, comfortable, and predictable experience that works on the widest range of XR hardware. For context, it may be helpful to have first read about [WebXR Session Establishment](explainer.md), and [Input Mechanisms](input-explainer.md).
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Contents
+
+- [Introduction](#introduction)
+- [Reference spaces](#reference-spaces)
+  - [Bounded reference space](#bounded-reference-space)
+  - [Unbounded reference space](#unbounded-reference-space)
+  - [Local reference spaces](#local-reference-spaces)
+    - [Eye-level local reference space](#eye-level-local-reference-space)
+    - [Floor-level local reference space](#floor-level-local-reference-space)
+  - [Viewer reference space](#viewer-reference-space)
+- [Spatial relationships](#spatial-relationships)
+  - [Rigid Transforms](#rigid-transforms)
+  - [Poses](#poses)
+    - [Tracking loss](#tracking-loss)
+    - [Tracking recovery](#tracking-recovery)
+  - [Application-supplied transforms](#application-supplied-transforms)
+  - [Relating between reference spaces](#relating-between-reference-spaces)
+    - [Inline to Immersive](#inline-to-immersive)
+    - [Unbounded to Bounded](#unbounded-to-bounded)
+  - [Click-and-drag view controls](#click-and-drag-view-controls)
+- [Practical-usage guidelines](#practical-usage-guidelines)
+  - [Inline sessions](#inline-sessions)
+  - [Ensuring hardware compatibility](#ensuring-hardware-compatibility)
+  - [Floor Alignment](#floor-alignment)
+  - [Reference space reset event](#reference-space-reset-event)
+- [Appendix A : Miscellaneous](#appendix-a--miscellaneous)
+  - [Tracking systems overview](#tracking-systems-overview)
+  - [Decision flow chart](#decision-flow-chart)
+  - [Reference space examples](#reference-space-examples)
+  - [XRReferenceSpace availability](#xrreferencespace-availability)
+- [Appendix B: Proposed partial IDL](#appendix-b-proposed-partial-idl)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Introduction
 A big differentiating aspect of XR, as opposed to standard 3D rendering, is that users control the view of the experience via their body motion.  To make this possible, XR hardware needs to be capable of tracking the user's motion in 3D space.  Within the XR ecosystem there is a wide range of hardware form factors and capabilities which have historically only been available to developers through device-specific SDKs and app platforms. To ship software in a specific app store, developers optimize their experiences for specific VR hardware (HTC Vive, GearVR, Mirage Solo, etc) or AR hardware (HoloLens, ARKit, ARCore, etc).  WebXR  development is fundamentally different in that regard; the Web gives developers broader reach, with the consequence that they no longer have predictability about the capability of the hardware their experiences will be running on.
 


### PR DESCRIPTION
/fixes #847

As demonstrated by #818, uses [doctoc] to generate tables of contents for all of our explainers. Some additional work could be done to make the results a little more terse, but this feels like a good first step. To update when the documents change, run `npm run doctoc`.


Also pulled over one or two minor changes from #818 that I liked and were easy to do quickly, but I'd like to do a more thorough pass at that later.