### PR TITLE
Use permissions API for XR feature requests

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2357,17 +2357,20 @@ To <dfn lt="request the xr permission">request the "xr" permission</dfn> with an
     1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"denied"}}.
     1. Abort these steps.
   1. Let <code>(|consentRequired|, |consentOptional|, |granted|)</code> be the fields of |result|.
+  1. The user agent MAY at this point perform any necessary steps, like showing permissions prompts, to determine if there is a clear signal of [=user intent=] for any features in |requiredFeatures| and |optionalFeatures|.
   1. For each |feature| in |consentRequired| perform the following steps:
+      1. The user agent MAY at this point perform any necessary steps, like showing permissions prompts, to determine if there is a clear signal of [=user intent=] for |feature|.
       1. If a clear signal of [=user intent=] to enable |feature| has not been determined, set |status|'s {{PermissionStatus/state}} to {{PermissionState/"denied"}} and abort these steps.
       1. If |feature| is not in |granted|, append |feature| to |granted|.
   1. For each |feature| in |consentOptional| perform the following steps:
+      1. The user agent MAY at this point perform any necessary steps, like showing permissions prompts, to determine if there is a clear signal of [=user intent=] for |feature|.
       1. If a clear signal of [=user intent=] to enable |feature| has not been determined, continue to the next entry.
       1. If |feature| is not in |granted|, append |feature| to |granted|.
   1. Set |status|'s {{XRPermissionStatus/granted}} to |granted|.
   1. Set |session|'s [=list of enabled features=] to |granted|.
   1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"granted"}}.
 
-Note: The user agent may choose to batch up permissions prompts for all requested features when gauging if there is a clear signal of [=user intent=].
+Note: The user agent has the freedom to batch up permissions prompts for all requested features when gauging if there is a clear signal of [=user intent=], but it is also allowed to show them one at a time.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -199,6 +199,9 @@ An <dfn for="">XR device</dfn> is a physical unit of hardware that can present i
 
 An [=/XR device=] has a <dfn>list of supported modes</dfn> (a [=/list=] of [=/strings=]) that [=list/contains=] the enumeration values of {{XRSessionMode}} that the [=/XR device=] supports.
 
+Each [=/XR device=] has a <dfn for="XR device">list of enabled features</dfn> for each {{XRSessionMode}} in its [=list of supported modes=], which is a [=/list=] of [=feature descriptors=] which MUST be initially an empty [=/list=].
+
+
 The user-agent MUST have an <dfn>inline XR device</dfn>, which is an [=/XR device=] that MUST [=list/contains|contain=] {{XRSessionMode/"inline"}} in its [=list of supported modes=]. The [=inline XR device=] SHOULD report as much pose information of the physical device the user agent is rendering to as possible. This device MAY be the same as the [=XR/immersive XR device=] if one is present, but doesn't have to be.
 
 Note: On phones, the [=inline XR device=] may report pose information derived from the phone's internal sensors, such as the gyroscope and accelerometer. On desktops and laptops without similar sensors, the [=inline XR device=] will not be able to report a pose. In case the user agent is already running on an [=/XR device=], the [=inline XR device=] will be the same device, and may support multiple [=view|views=].
@@ -259,6 +262,7 @@ Each time the [=list of immersive XR devices=] changes the user agent should <df
   1. [=Shut down the session|Shut down=] any active {{XRSession}}s.
   1. Set the [=XR compatible=] boolean of all {{WebGLRenderingContextBase}} instances to <code>false</code>.
   1. [=Queue a task=] to [=fire an event=] named {{devicechange!!event}} on the [=context object=].
+  1. [=Queue a task=] to fire appropriate <code>change</code> events on any {{XRPermissionStatus}} objects who are affected by the change in the [=XR/immersive XR device=] or [=inline XR device=].
 
 </div>
 
@@ -332,16 +336,7 @@ When this method is invoked, the user agent MUST run the following steps:
       <dd>Check if an [=inline session request is allowed=], and if not [=reject=] |promise| with a "{{SecurityError}}" {{DOMException}} and return |promise|.</dd>
     </dl>
   1. Run the following steps [=in parallel=]:
-    1. Choose |device| as follows:
-        <dl class="switch">
-          <dt>If |immersive| is <code>true</code></dt>
-          <dd>
-              1. [=ensures an immersive XR device is selected|Ensure an immersive XR device is selected=].
-              1. Set |device| to the [=XR/immersive XR device=].
-          </dd>
-          <dt>Otherwise</dt>
-          <dd>Set |device| to the [=inline XR device=].</dd>
-        </dl>
+    1. Set |device| to the result of [=obtain the current device|obtaining the current device=] for |mode|.
     1. [=Queue a task=] to perform the following steps:
         1. If |device| is <code>null</code> or |device|'s [=list of supported modes=] does not [=list/contain=] |mode|, run the following steps:
             1. [=Reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
@@ -365,6 +360,24 @@ When this method is invoked, the user agent MUST run the following steps:
             </dl>
         1. [=/Resolve=] |promise| with |session|.
   1. Return |promise|.
+
+</div>
+
+<div class=algorithm data-algorithm="device-for-mode">
+
+To <dfn>obtain the current device</dfn> for an {{XRSessionMode}} |mode|, the user agent MUST run the following steps:
+
+  1. Choose |device| as follows:
+      <dl class="switch">
+        <dt>If |mode| is an [=immersive session=] mode:</dt>
+        <dd>
+            1. [=ensures an immersive XR device is selected|Ensure an immersive XR device is selected=].
+            1. Set |device| to the [=XR/immersive XR device=].
+        </dd>
+        <dt>Otherwise</dt>
+        <dd>Set |device| to the [=inline XR device=].</dd>
+      </dl>
+  1. Return |device|.
 
 </div>
 
@@ -591,8 +604,6 @@ The <dfn method for="XRSession">end()</dfn> method provides a way to manually sh
   1. Return |promise|.
 
 </div>
-
-Each {{XRSession}} has a <dfn for="XRSession">list of enabled features</dfn>, which is a [=/list=] of [=feature descriptors=] which MUST be initially an empty [=/list=]
 
 Each {{XRSession}} has an <dfn>active render state</dfn> which is a new {{XRRenderState}}, and a <dfn>pending render state</dfn>, which is an {{XRRenderState}} which is initially <code>null</code>.
 
@@ -1101,7 +1112,7 @@ When an {{XRReferenceSpace}} is requested, the user agent MUST <dfn>create a ref
 <div class="algorithm" data-algorithm="reference-space-supported">
 To check if a <dfn>reference space is supported</dfn> for a given reference space type |type| and {{XRSession}} |session|, run the following steps:
 
-  1. If |type| is not [=list/contain|contained=] in |session|'s [=list of enabled features=] return <code>false</code>.
+  1. If |type| is not [=list/contain|contained=] in |session|'s [=XRSession/XR device=]'s [=XR device/list of enabled features=] for [=XRSession/mode=] return <code>false</code>.
   1. If |type| is {{viewer}}, return <code>true</code>.
   1. If |type| is {{local}} or {{local-floor}}, and |session| is an [=immersive session=], return <code>true</code>.
   1. If |type| is {{local}} or {{local-floor}}, and the [=XRSession/XR device=] supports reporting orientation data, return <code>true</code>.
@@ -2324,7 +2335,7 @@ The <dfn enum-value for="PermissionName">"xr"</dfn> [=powerful feature=]’s per
 
 <pre class="idl">
 dictionary XRPermissionDescriptor: PermissionDescriptor {
-  XRSession session;
+  XRSessionMode mode;
   sequence&lt;any&gt; requiredFeatures;
   sequence&lt;any&gt; optionalFeatures;
 };
@@ -2352,7 +2363,8 @@ dictionary XRPermissionStatus: PermissionStatus {
 To <dfn lt="request the xr permission">request the "xr" permission</dfn> with an {{XRPermissionDescriptor}} |descriptor| and a {{XRPermissionStatus}} |status|, the UA MUST run the following steps:
 
   1. Set |status|'s {{XRPermissionStatus/granted}} to an empty {{FrozenArray}}.
-  1. Let |result| be the result of [=resolve the requested features|resolving the requested features=] given |descriptor|'s {{XRPermissionDescriptor/requiredFeatures}}, {{XRPermissionDescriptor/optionalFeatures}}, and {{XRPermissionDescriptor/session}}.
+  1. Let |device| be the result of [=obtain the current device|obtaining the current device=] for |mode|.
+  1. Let |result| be the result of [=resolve the requested features|resolving the requested features=] given |descriptor|'s {{XRPermissionDescriptor/requiredFeatures}}, {{XRPermissionDescriptor/optionalFeatures}}, and {{XRPermissionDescriptor/mode}}.
   1. If |result| is <code>null</code>, run the following steps:
     1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"denied"}}.
     1. Abort these steps.
@@ -2367,7 +2379,7 @@ To <dfn lt="request the xr permission">request the "xr" permission</dfn> with an
       1. If a clear signal of [=user intent=] to enable |feature| has not been determined, continue to the next entry.
       1. If |feature| is not in |granted|, append |feature| to |granted|.
   1. Set |status|'s {{XRPermissionStatus/granted}} to |granted|.
-  1. Set |session|'s [=list of enabled features=] to |granted|.
+  1. Set |device|'s [=list of enabled features=] for |mode| to |granted|.
   1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"granted"}}.
 
 Note: The user agent has the freedom to batch up permissions prompts for all requested features when gauging if there is a clear signal of [=user intent=], but it is also allowed to show them one at a time.
@@ -2382,7 +2394,7 @@ To query the "xr" permission with an {{XRPermissionDescriptor}} |descriptor| and
 
   1. Set |status|'s {{PermissionStatus/state}} to |descriptor|'s [=permission state=].
   1. If |status|'s {{PermissionStatus/state}} is {{PermissionState/"denied"}}, set |status|'s {{XRPermissionStatus/granted}} to an empty {{FrozenArray}} and abort these steps.
-  1. Let |result| be the result of [=resolve the requested features|resolving the requested features=] given |descriptor|'s {{XRPermissionDescriptor/requiredFeatures}}, {{XRPermissionDescriptor/optionalFeatures}}, and {{XRPermissionDescriptor/session}}.
+  1. Let |result| be the result of [=resolve the requested features|resolving the requested features=] given |descriptor|'s {{XRPermissionDescriptor/requiredFeatures}}, {{XRPermissionDescriptor/optionalFeatures}}, and {{XRPermissionDescriptor/mode}}.
   1. If |result| is <code>null</code>, run the following steps:
     1. Set |status|'s {{XRPermissionStatus/granted}} to an empty {{FrozenArray}}.
     1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"denied"}}.
@@ -2400,12 +2412,15 @@ To query the "xr" permission with an {{XRPermissionDescriptor}} |descriptor| and
 
 <div class="algorithm" data-algorithm="resolve-features">
 
-To <dfn>resolve the requested features</dfn> given |requiredFeatures| and |optionalFeatures| for an {{XRSession}} |session|, the user agent MUST run the following steps:
+To <dfn>resolve the requested features</dfn> given |requiredFeatures| and |optionalFeatures| for an {{XRSessionMode}} |mode|, the user agent MUST run the following steps:
 
   1. Let |consentRequired| be an empty [=/list=] of {{DOMString}}.
   1. Let |consentOptional| be an empty [=/list=] of {{DOMString}}.
-  1. Let |granted| be a [=/list=] of {{DOMString}} initialized to |session|'s [=list of enabled features=].
-  1. Add every [=feature descriptor=] in the [=default features=] table associated with |session|'s [=XRSession/mode=] to the indicated feature list if it is not already present.
+  1. Let |device| be the result of [=obtain the current device|obtaining the current device=] for |mode|.
+  1. Let |granted| be a [=/list=] of {{DOMString}} initialized to |device|'s [=XR device/list of enabled features=] for |mode|.
+  1. If |device| is <code>null</code> or |device|'s [=list of supported modes=] does not [=list/contain=] |mode|, run the following steps:
+    1. Return the [=tuple=] <code>(|consentRequired|, |consentOptional|, |granted|)</code>
+  1. Add every [=feature descriptor=] in the [=default features=] table associated with |mode| to the indicated feature list if it is not already present.
   1. For each |feature| in |requiredFeatures| perform the following steps:
     1. If |feature| is not a valid [=feature descriptor=], return <code>null</code>.
     1. If |feature| is already in |granted|, continue to the next entry.

--- a/index.bs
+++ b/index.bs
@@ -2351,9 +2351,9 @@ dictionary XRPermissionStatus: PermissionStatus {
 <div class=algorithm data-algorithm="xr-permission-request-algorithm">
 To <dfn lt="request the xr permission">request the "xr" permission</dfn> with an {{XRPermissionDescriptor}} |descriptor| and a {{XRPermissionStatus}} |status|, the UA MUST run the following steps:
 
+  1. Set |status|'s {{XRPermissionStatus/granted}} to an empty {{FrozenArray}}.
   1. Let |result| be the result of [=resolve the requested features|resolving the requested features=] given |descriptor|'s {{XRPermissionDescriptor/requiredFeatures}}, {{XRPermissionDescriptor/optionalFeatures}}, and {{XRPermissionDescriptor/session}}.
   1. If |result| is <code>null</code>, run the following steps:
-    1. Set |status|'s {{XRPermissionStatus/granted}} to an empty {{FrozenArray}}.
     1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"denied"}}.
     1. Abort these steps.
   1. Let <code>(|consentRequired|, |consentOptional|, |granted|)</code> be the fields of |result|.

--- a/index.bs
+++ b/index.bs
@@ -350,7 +350,6 @@ When this method is invoked, the user agent MUST run the following steps:
         1. Let |session| be a new {{XRSession}} object.
         1. [=Initialize the session=] with |session|, |mode|, and |device|.
         1. Let |descriptor| be an {{XRPermissionDescriptor}} initialized with |session|, |options|' {{XRSessionInit/requiredFeatures}}, and |options|' {{XRSessionInit/optionalFeatures}}.
-        1. Let |descriptor| be an {{XRPermissionDescriptor}} initialized with |session|, |options|' {{XRSessionInit/requiredFeatures}}, and |options|' {{XRSessionInit/optionalFeatures}}.
         1. Let |status| be an {{XRPermissionStatus}}, initially <code>null</code>
         1. [=Request the xr permission=] with |descriptor| and |status|.
         1. If |status|' {{PermissionStatus/state}} is {{PermissionState/"denied"}} run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -23,6 +23,9 @@ Abstract: This specification describes support for accessing virtual reality (VR
 <pre class="link-defaults">
 spec:infra;
     type:dfn; text:string
+    type:dfn; text:tuple
+spec:permissions-1;
+    type:dfn; text:powerful feature
 </pre>
 
 <pre class="anchors">
@@ -346,11 +349,15 @@ When this method is invoked, the user agent MUST run the following steps:
             1. Abort these steps.
         1. Let |session| be a new {{XRSession}} object.
         1. [=Initialize the session=] with |session|, |mode|, and |device|.
-        1. [=Resolve the requested features=] given by |options|' {{XRSessionInit/requiredFeatures}} and |options|' {{XRSessionInit/optionalFeatures}} values for |session|, and let |resolved| be the returned value.
-        1. If |resolved| is <code>false</code>, run the following steps:
+        1. Let |descriptor| be an {{XRPermissionDescriptor}} initialized with |session|, |options|' {{XRSessionInit/requiredFeatures}}, and |options|' {{XRSessionInit/optionalFeatures}}.
+        1. Let |descriptor| be an {{XRPermissionDescriptor}} initialized with |session|, |options|' {{XRSessionInit/requiredFeatures}}, and |options|' {{XRSessionInit/optionalFeatures}}.
+        1. Let |status| be an {{XRPermissionStatus}}, initially <code>null</code>
+        1. [=Request the xr permission=] with |descriptor| and |status|.
+        1. If |status|' {{PermissionStatus/state}} is {{PermissionState/"denied"}} run the following steps:
             1. [=Reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
             1. If |immersive| is <code>true</code>, set [=pending immersive session=] to <code>false</code>.
             1. Abort these steps.
+        1. Set |session|'s [=list of enabled features=] to |status|' {{XRPermissionStatus/granted}}.
         1. Potentially set the [=active immersive session=] as follows:
             <dl class="switch">
               <dt> If |immersive| is <code>true</code>
@@ -495,36 +502,6 @@ Note: {{XRReferenceSpaceType/"local"}} is always included in the [=requested fea
 [=Requested features=] can only be enabled for a session if the [=XRSession/XR device=] is <dfn>capable of supporting</dfn> the feature, which means that the feature is known to be supported by the [=XRSession/XR device=] in some configurations, even if the current configuration has not yet been verified as supporting the feature. The user agent MAY apply more rigorous constraints if desired in order to yield a more consistent user experience.
 
 Note: For example, several VR devices support either configuring a safe boundary for the user to move around within or skipping boundary configuration and operating in a mode where the user is expected to stand in place. Such a device can be considered to be [=capable of supporting=] {{"bounded-floor"}} {{XRReferenceSpace}}s even if they are currently not configured with safety boundaries, because it's expected that the user could configure the device appropriately if the experience required it. This is to allow user agents to avoid fully initializing the [=XRSession/XR device=] or waiting for the user's environment to be recognized prior to [=resolve the requested features|resolving the requested features=] if desired. If, however, the user agent knows that the boundary state at the time the session is requested without additional initialization it may choose to reject the {{"bounded-floor"}} feature if the safety boundary not already configured.
-
-<div class="algorithm" data-algorithm="resolve-features">
-
-To <dfn>resolve the requested features</dfn> given |requiredFeatures| and |optionalFeatures| for an {{XRSession}} |session|, the user agent MUST run the following steps:
-
-  1. Let |consentRequired| be an empty [=/list=] of {{DOMString}}.
-  1. Let |consentOptional| be an empty [=/list=] of {{DOMString}}.
-  1. Add every [=feature descriptor=] in the [=default features=] table associated with |session|'s [=XRSession/mode=] to the indicated feature list if it is not already present.
-  1. For each |feature| in |requiredFeatures| perform the following steps:
-    1. If |feature| is not a valid [=feature descriptor=], return <code>false</code>.
-    1. If the requesting document's origin is not allowed to use any [[#feature-policy|feature policy]] required by |feature| as indicated by the [=feature requirements=] table, return <code>false</code>.
-    1. If |session|'s [=XRSession/XR device=] is not [=capable of supporting=] the functionality described by |feature| or the user agent has otherwise determined to reject the feature, return <code>false</code>.
-    1. If the functionality described by |feature| requires [=explicit consent=], append it to |consentRequired|.
-    1. Else append |feature| to |session|'s [=list of enabled features=].
-  1. For each |feature| in |optionalFeatures| perform the following steps:
-    1. If |feature| is not a valid [=feature descriptor=], continue to the next entry.
-    1. If the requesting document's origin is not allowed to use any [[#feature-policy|feature policy]] required by |feature| as indicated by the [=feature requirements=] table, continue to the next entry.
-    1. If |session|'s [=XRSession/XR device=] is not [=capable of supporting=] the functionality described by |feature| or the user agent has otherwise determined to reject the feature, continue to the next entry.
-    1. If the functionality described by |feature| requires [=explicit consent=], append it to |consentOptional|.
-    1. Else append |feature| to |session|'s [=list of enabled features=].
-  1. If |consentRequired| or |consentOptional| are not empty, request [=explicit consent=] to use the functionality described by those features.
-  1. For each |feature| in |consentRequired| perform the following steps:
-    1. If a clear signal of [=user intent=] to enable |feature| has not been given, return <code>false</code>.
-    1. Else append |feature| to |session|'s [=list of enabled features=].
-  1. For each |feature| in |consentOptional| perform the following steps:
-    1. If a clear signal of [=user intent=] to enable |feature| has not been given, continue to the next entry.
-    1. Else append |feature| to |session|'s [=list of enabled features=].
-  1. Return <code>true</code>
-
-</div>
 
 Session {#session}
 =======
@@ -2333,6 +2310,117 @@ The feature identifier for this feature is <code>"xr-spatial-tracking"</code>.
 The [=default allowlist=] for this feature is <code>["self"]</code>.
 
 Note: If the document's origin is not allowed to use the <code>"xr-spatial-tracking"</code> feature policy any [=immersive sessions=] will be blocked, because all [=immersive sessions=] require some use of spatial tracking. [=Inline sessions=] will still be allowed, but restricted to only using the {{XRReferenceSpaceType/"viewer"}} {{XRReferenceSpace}}.
+
+
+Permissions API Integration {#permissions}
+---------
+
+The [[!permissions]] API provides a uniform way for websites to request permissions from users and query which permissions they have. 
+
+The <dfn enum-value for="PermissionName">"xr"</dfn> [=powerful feature=]’s permission-related algorithms and types are defined as follows: 
+
+
+<dl>
+<dt>[=permission descriptor type=]</dt>
+<dd>
+
+<pre class="idl">
+dictionary XRPermissionDescriptor: PermissionDescriptor {
+  XRSession session;
+  sequence&lt;any&gt; requiredFeatures;
+  sequence&lt;any&gt; optionalFeatures;
+};
+</pre>
+
+where {{PermissionDescriptor/name}} is {{PermissionName/"xr"}}.
+
+
+</dd>
+
+<dt>[=permission result type=]</dt>
+<dd>
+<pre class=idl>
+dictionary XRPermissionStatus: PermissionStatus {
+  sequence&lt;any&gt; granted;
+};
+</pre>
+
+</dd>
+
+
+<dt>[=permission request algorithm=]</dt>
+<dd>
+<div class=algorithm data-algorithm="xr-permission-request-algorithm">
+To <dfn lt="request the xr permission">request the "xr" permission</dfn> with an {{XRPermissionDescriptor}} |descriptor| and a {{XRPermissionStatus}} |status|, the UA MUST run the following steps:
+
+  1. Let |result| be the result of [=resolve the requested features|resolving the requested features=] given |descriptor|'s {{XRPermissionDescriptor/requiredFeatures}}, {{XRPermissionDescriptor/optionalFeatures}}, and {{XRPermissionDescriptor/session}}.
+  1. If |result| is <code>null</code>, run the following steps:
+    1. Set |status|'s {{XRPermissionStatus/granted}} to an empty {{FrozenArray}}.
+    1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"denied"}}.
+    1. Abort these steps.
+  1. Let <code>(|consentRequired|, |consentOptional|, |granted|)</code> be the fields of |result|.
+  1. For each |feature| in |consentRequired| perform the following steps:
+      1. If a clear signal of [=user intent=] to enable |feature| has not been given, set |status|'s   {{PermissionStatus/state}} to {{PermissionState/"denied"}} and abort these steps.
+      1. If |feature| is not in |granted|, append |feature| to |granted|.
+  1. For each |feature| in |consentOptional| perform the following steps:
+      1. If a clear signal of [=user intent=] to enable |feature| has not been given, continue to the next entry.
+      1. If |feature| is not in |granted|, append |feature| to |granted|.
+  1. Set |status|'s {{XRPermissionStatus/granted}} to |granted|.
+  1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"granted"}}.
+
+Note: The user agent may choose to batch up permissions prompts for all requested features when gauging if there is a clear signal of [=user intent=].
+
+</div>
+
+
+<dt>[=permission query algorithm=]</dt>
+<dd>
+<div class=algorithm data-algorithm="xr-permission-query-algorithm">
+To query the "xr" permission with an {{XRPermissionDescriptor}} |descriptor| and a {{XRPermissionStatus}} |status|, the UA MUST run the following steps:
+
+  1. Set |status|'s {{PermissionStatus/state}} to |descriptor|'s [=permission state=].
+  1. If |status|'s {{PermissionStatus/state}} is {{PermissionState/"denied"}}, set |status|'s {{XRPermissionStatus/granted}} to an empty {{FrozenArray}} and abort these steps.
+  1. Let |result| be the result of [=resolve the requested features|resolving the requested features=] given |descriptor|'s {{XRPermissionDescriptor/requiredFeatures}}, {{XRPermissionDescriptor/optionalFeatures}}, and {{XRPermissionDescriptor/session}}.
+  1. If |result| is <code>null</code>, run the following steps:
+    1. Set |status|'s {{XRPermissionStatus/granted}} to an empty {{FrozenArray}}.
+    1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"denied"}}.
+    1. Abort these steps.
+  1. Let <code>(|consentRequired|, |consentOptional|, |granted|)</code> be the fields of |result|.
+  1. Set |status|'s {{XRPermissionStatus/granted}} to |granted|.
+  1. If |consentRequired| [=list/is empty=] and |consentOptional| [=list/is empty=], set |status|'s {{PermissionStatus/state}} to {{PermissionState/"granted"}} and abort these steps
+  1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"prompt"}}.
+
+</div>
+
+</dd>
+
+</dl>
+
+<div class="algorithm" data-algorithm="resolve-features">
+
+To <dfn>resolve the requested features</dfn> given |requiredFeatures| and |optionalFeatures| for an {{XRSession}} |session|, the user agent MUST run the following steps:
+
+  1. Let |consentRequired| be an empty [=/list=] of {{DOMString}}.
+  1. Let |consentOptional| be an empty [=/list=] of {{DOMString}}.
+  1. Let |granted| be a [=/list=] of {{DOMString}} initialized to |session|'s [=list of enabled features=].
+  1. Add every [=feature descriptor=] in the [=default features=] table associated with |session|'s [=XRSession/mode=] to the indicated feature list if it is not already present.
+  1. For each |feature| in |requiredFeatures| perform the following steps:
+    1. If |feature| is not a valid [=feature descriptor=], return <code>null</code>.
+    1. If |feature| is already in |granted|, continue to the next entry.
+    1. If the requesting document's origin is not allowed to use any [[#feature-policy|feature policy]] required by |feature| as indicated by the [=feature requirements=] table, return <code>null</code>.
+    1. If |session|'s [=XRSession/XR device=] is not [=capable of supporting=] the functionality described by |feature| or the user agent has otherwise determined to reject the feature, return <code>null</code>.
+    1. If the functionality described by |feature| requires [=explicit consent=], append it to |consentRequired|.
+    1. Else append |feature| to |granted|.
+  1. For each |feature| in |optionalFeatures| perform the following steps:
+    1. If |feature| is not a valid [=feature descriptor=], continue to the next entry.
+    1. If |feature| is already in |granted|, continue to the next entry.
+    1. If the requesting document's origin is not allowed to use any [[#feature-policy|feature policy]] required by |feature| as indicated by the [=feature requirements=] table, continue to the next entry.
+    1. If |session|'s [=XRSession/XR device=] is not [=capable of supporting=] the functionality described by |feature| or the user agent has otherwise determined to reject the feature, continue to the next entry.
+    1. If the functionality described by |feature| requires [=explicit consent=], append it to |consentOptional|.
+    1. Else append |feature| to |granted|.
+  1. Return the [=tuple=] <code>(|consentRequired|, |consentOptional|, |granted|)</code>
+
+</div>
 
 Acknowledgements {#ack}
 ================

--- a/index.bs
+++ b/index.bs
@@ -2357,13 +2357,13 @@ To <dfn lt="request the xr permission">request the "xr" permission</dfn> with an
     1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"denied"}}.
     1. Abort these steps.
   1. Let <code>(|consentRequired|, |consentOptional|, |granted|)</code> be the fields of |result|.
-  1. The user agent MAY at this point perform any necessary steps, like showing permissions prompts, to determine if there is a clear signal of [=user intent=] for any features in |requiredFeatures| and |optionalFeatures|.
+  1. The user agent MAY at this point ask the user’s permission for the calling algorithm to use any of the features in |consentRequired| and |consentOptional|. The results of these prompts should be included when determining if there is a clear signal of [=user intent=] for enabling these features.
   1. For each |feature| in |consentRequired| perform the following steps:
-      1. The user agent MAY at this point perform any necessary steps, like showing permissions prompts, to determine if there is a clear signal of [=user intent=] for |feature|.
+      1. The user agent MAY at this point ask the user’s permission for the calling algorithm to use |feature|. The results of these prompts should be included when determining if there is a clear signal of [=user intent=] to enable |feature|.
       1. If a clear signal of [=user intent=] to enable |feature| has not been determined, set |status|'s {{PermissionStatus/state}} to {{PermissionState/"denied"}} and abort these steps.
       1. If |feature| is not in |granted|, append |feature| to |granted|.
   1. For each |feature| in |consentOptional| perform the following steps:
-      1. The user agent MAY at this point perform any necessary steps, like showing permissions prompts, to determine if there is a clear signal of [=user intent=] for |feature|.
+      1. The user agent MAY at this point ask the user’s permission for the calling algorithm to use |feature|. The results of these prompts should be included when determining if there is a clear signal of [=user intent=] to enable |feature|.
       1. If a clear signal of [=user intent=] to enable |feature| has not been determined, continue to the next entry.
       1. If |feature| is not in |granted|, append |feature| to |granted|.
   1. Set |status|'s {{XRPermissionStatus/granted}} to |granted|.

--- a/index.bs
+++ b/index.bs
@@ -356,7 +356,6 @@ When this method is invoked, the user agent MUST run the following steps:
             1. [=Reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
             1. If |immersive| is <code>true</code>, set [=pending immersive session=] to <code>false</code>.
             1. Abort these steps.
-        1. Set |session|'s [=list of enabled features=] to |status|' {{XRPermissionStatus/granted}}.
         1. Potentially set the [=active immersive session=] as follows:
             <dl class="switch">
               <dt> If |immersive| is <code>true</code>
@@ -2365,6 +2364,7 @@ To <dfn lt="request the xr permission">request the "xr" permission</dfn> with an
       1. If a clear signal of [=user intent=] to enable |feature| has not been given, continue to the next entry.
       1. If |feature| is not in |granted|, append |feature| to |granted|.
   1. Set |status|'s {{XRPermissionStatus/granted}} to |granted|.
+  1. Set |session|'s [=list of enabled features=] to |granted|.
   1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"granted"}}.
 
 Note: The user agent may choose to batch up permissions prompts for all requested features when gauging if there is a clear signal of [=user intent=].

--- a/index.bs
+++ b/index.bs
@@ -2313,7 +2313,7 @@ Note: If the document's origin is not allowed to use the <code>"xr-spatial-track
 Permissions API Integration {#permissions}
 ---------
 
-The [[!permissions]] API provides a uniform way for websites to request permissions from users and query which permissions they have. 
+The [[!permissions]] API provides a uniform way for websites to request permissions from users and query which permissions they have been granted. 
 
 The <dfn enum-value for="PermissionName">"xr"</dfn> [=powerful feature=]’s permission-related algorithms and types are defined as follows: 
 
@@ -2330,7 +2330,7 @@ dictionary XRPermissionDescriptor: PermissionDescriptor {
 };
 </pre>
 
-where {{PermissionDescriptor/name}} is {{PermissionName/"xr"}}.
+{{PermissionDescriptor/name}} for {{XRPermissionDescriptor}} is {{PermissionName/"xr"}}.
 
 
 </dd>
@@ -2358,10 +2358,10 @@ To <dfn lt="request the xr permission">request the "xr" permission</dfn> with an
     1. Abort these steps.
   1. Let <code>(|consentRequired|, |consentOptional|, |granted|)</code> be the fields of |result|.
   1. For each |feature| in |consentRequired| perform the following steps:
-      1. If a clear signal of [=user intent=] to enable |feature| has not been given, set |status|'s   {{PermissionStatus/state}} to {{PermissionState/"denied"}} and abort these steps.
+      1. If a clear signal of [=user intent=] to enable |feature| has not been determined, set |status|'s {{PermissionStatus/state}} to {{PermissionState/"denied"}} and abort these steps.
       1. If |feature| is not in |granted|, append |feature| to |granted|.
   1. For each |feature| in |consentOptional| perform the following steps:
-      1. If a clear signal of [=user intent=] to enable |feature| has not been given, continue to the next entry.
+      1. If a clear signal of [=user intent=] to enable |feature| has not been determined, continue to the next entry.
       1. If |feature| is not in |granted|, append |feature| to |granted|.
   1. Set |status|'s {{XRPermissionStatus/granted}} to |granted|.
   1. Set |session|'s [=list of enabled features=] to |granted|.


### PR DESCRIPTION
[Rendered](https://api.csswg.org/bikeshed/?force=1&url=https://raw.githubusercontent.com/Manishearth/webxr/consent-tracking/index.bs)

This makes our feature request algorithm reuse machinery from the [Permissions API](https://w3c.github.io/permissions), making it possible to do things like query consent status.

We define a _single_ "xr" feature, however the query is done through a new `XRPermissionDescriptor` type which contains additional information about the requested features and the session.


In the current implementation, requested features are not persisted across sessions (which enables sessions with different modes, and sessions using different devices to have different granted features). However, there is nothing stopping the user agent from persisting granted features where it feels it prudent, since the spec relies on there being a "clear signal of user intent".


I'm not 100% sure of this approach, and I suspect this may go through a bunch of changes, hence the draft PR.

r? @NellWaliczek @toji

/fixes #794, /fixes #722, /fixes #702, /fixes #725

(maybe also #725?)