### PR TITLE
Unset animationFrame boolean at end of frame

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -881,6 +881,7 @@ When an {{XRSession}} |session| receives updated [=viewer=] state from the [=XRS
     1. If the entry's [=cancelled=] boolean is <code>true</code>, continue to the next entry.
     1. [=Invoke the Web IDL callback function=], passing |now| and |frame| as the  arguments
     1. If an exception is thrown, [=report the exception=].
+  1. Set |frame|'s [=animationFrame=] boolean to <code>false</code>.
   1. Set |frame|'s [=active=] boolean to <code>false</code>.
 
 </div>


### PR DESCRIPTION
The XRFrame's private animationFrame boolean is set to true during the frame handler but never set back to false. This seems like the right place to add it.