### PR TITLE
Mark XRWebGLLayer.framebuffer as nullable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1703,7 +1703,7 @@ interface XRWebGLLayer {
   readonly attribute boolean antialias;
   readonly attribute boolean ignoreDepthValues;
 
-  [SameObject] readonly attribute WebGLFramebuffer framebuffer;
+  [SameObject] readonly attribute WebGLFramebuffer? framebuffer;
   readonly attribute unsigned long framebufferWidth;
   readonly attribute unsigned long framebufferHeight;
 


### PR DESCRIPTION
The text defining it already allows it to be null