### PR TITLE
Clarify bounded reference space behavior

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1207,6 +1207,8 @@ Note: It is suggested that points of the [=native bounds geometry=] be [=quantiz
 
 The <dfn attribute for="XRBoundedReferenceSpace">boundsGeometry</dfn> attribute is an array of {{DOMPointReadOnly}}s such that each entry is equal to the entry in the {{XRBoundedReferenceSpace}}'s [=XRBoundedReferenceSpace/native bounds geometry=] premultiplied by the {{XRRigidTransform/inverse}} of the [=XRSpace/origin offset=]. In other words, it provides the same border in {{XRBoundedReferenceSpace}} coordinates relative to the [=XRSpace/effective origin=].
 
+If the [=native bounds geometry=] is temporarily unavailable, which may occur for several reasons such as during XR device initialization, extended periods of tracking loss, or movement between pre-configured spaces, the {{boundsGeometry}} MUST report an empty array.
+
 
 <div class="algorithm" data-algorithm="bounded-space-supported">
 To check if <dfn>bounded reference spaces are supported</dfn> run the following steps:
@@ -1215,6 +1217,7 @@ To check if <dfn>bounded reference spaces are supported</dfn> run the following 
     1. Return true.
 </div>
 
+Note: Bounded references spaces may be returned if the boundaries or floor height have not been resolved at the time of the reference space request, but the XR device is known to support them.
 
 Note: Content should not require the user to move beyond the {{boundsGeometry}}. It is possible for the user to move beyond the bounds if their physical surroundings allow for it, resulting in position values outside of the polygon they describe. This is not an error condition and should be handled gracefully by page content.
 


### PR DESCRIPTION
/fixes #937 

Adds some clarifying text to the `XRBoundedReferenceSpace` definition to indicate that the `boundsGeometry` array must be set to an empty array (`[]`) if the bounds are not known, and that `bounded-floor` reference spaces are allowed to be returned even if the floor level or bounds geometry hasn't yet been resolved as long as the device is known to support it.

CC @thetuvix