### PR TITLE
Correctly resolve promise when end() is called on an ended session

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -612,6 +612,9 @@ When an {{XRSession}} is shut down the following steps are run:
 The <dfn method for="XRSession">end()</dfn> method provides a way to manually shut down a session. When invoked, it MUST run the following steps:
 
   1. Let |promise| be [=a new Promise=].
+  1. If |session|'s [=ended=] value is <code>true</code>, perform the following steps:
+    1. [=/Resolve=] |promise|.
+    1. Return |promise|.
   1. [=Shut down the session|Shut down=] the target {{XRSession}} object.
   1. [=Queue a task=] to perform the following steps:
     1. Wait until any platform-specific steps related to shutting down the session have completed.


### PR DESCRIPTION
Servo was timing out on some tests because they'd call `end()` multiple times and the second time it would never resolve the promise.

r? @toji