### PR TITLE
Improve code style in example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -370,11 +370,7 @@ When this method is invoked, the user agent MUST run the following steps:
 The following code attempts to retrieve an {{immersive-vr}} {{XRSession}}.
 
 <pre highlight="js">
-let xrSession;
-
-navigator.xr.requestSession("immersive-vr").then((session) => {
-  xrSession = session;
-});
+const xrSession = await navigator.xr.requestSession("immersive-vr");
 </pre>
 </div>
 


### PR DESCRIPTION
Declaring a `let` variable globally and then setting its value inside a `.then()` is bad practice and can lead less experienced programmers down a faulty (or even racey) path.

I’d recommend using modern JS with async/await. I only updated the first example here to start a discussion, I am happy to update the later example if the spec editors find this beneficial and/or valuable :D