### PR TITLE
Potentially update the inline device when the device changes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -255,6 +255,7 @@ Each time the [=list of immersive XR devices=] changes the user agent should <df
       <dt> Otherwise
       <dd> Set the [=XR/immersive XR device=] to a device of the user agent's choosing
     </dl>
+  1. The user agent MAY update the [=XR/inline XR device=] to the [=XR/immersive XR device=] or an emulated inline device if it wishes.
   1. If this is the first time devices have been enumerated or |oldDevice| equals the [=XR/immersive XR device=], abort these steps.
   1. [=Shut down the session|Shut down=] any active {{XRSession}}s.
   1. Set the [=XR compatible=] boolean of all {{WebGLRenderingContextBase}} instances to <code>false</code>.


### PR DESCRIPTION
This was kind of missed in https://github.com/immersive-web/webxr/pull/737

Basically, if the user "switches into" viewing the page on an immersive XR device after the page has already loaded, inline sessions should be able to use and request tracking.

This does mean you can request an inline session while viewing the page in immersive mode, remove and disconnect the headset, and then have an inline session that was previously allowed to use tracking spaces but no longer can. This is a bit of a weird wrinkle but I think in the current situation it will just refuse to return poses, which is fine.

r? @toji