### PR TITLE
Turn XRPermissionStatus into an interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2378,8 +2378,8 @@ dictionary XRPermissionDescriptor: PermissionDescriptor {
 <dt>[=permission result type=]</dt>
 <dd>
 <pre class=idl>
-dictionary XRPermissionStatus: PermissionStatus {
-  sequence&lt;any&gt; granted;
+interface XRPermissionStatus: PermissionStatus {
+  attribute FrozenArray<any> granted;
 };
 </pre>
 


### PR DESCRIPTION
Unsure if I should use a FrozenArray or an `any[]` here, I think it's fine to use a frozen array even though the attribute _can_ change because then the entire attribute will change (it's not `[SameObject]`)

/fixes #965 
r? @toji