### PR TITLE
Use realm from XRSession in end()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -633,7 +633,7 @@ When an {{XRSession}} is shut down the following steps are run:
 
 The <dfn method for="XRSession">end()</dfn> method provides a way to manually shut down a session. When invoked, it MUST run the following steps:
 
-  1. Let |promise| be [=a new Promise=] in the [=relevant realm=] of this {{XRSystem}}.
+  1. Let |promise| be [=a new Promise=] in the [=relevant realm=] of this {{XRSession}}.
   1. [=Shut down the session|Shut down=] the target {{XRSession}} object.
   1. [=Queue a task=] to perform the following steps:
     1. Wait until any platform-specific steps related to shutting down the session have completed.


### PR DESCRIPTION
Small thing I caught during review


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1026.html" title="Last updated on May 11, 2020, 9:12 PM UTC (9edb45a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1026/08ed34a...Manishearth:9edb45a.html" title="Last updated on May 11, 2020, 9:12 PM UTC (9edb45a)">Diff</a>