### PR TITLE
Cleanups on how we do tasks and promises

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -313,8 +313,8 @@ When this method is invoked, it MUST run the following steps:
   1. Run the following steps [=in parallel=]:
     1. [=ensures an immersive XR device is selected|Ensure an immersive XR device is selected=].
     1. If the [=XRSystem/immersive XR device=] is null, [=/resolve=] |promise| with <code>false</code> and abort these steps.
-    1. If the [=XRSystem/immersive XR device=]'s [=list of supported modes=] does not [=list/contain=] |mode|, [=/resolve=] |promise| with <code>false</code> and abort these steps.
-    1. [=/Resolve=] |promise| with <code>true</code>.
+    1. If the [=XRSystem/immersive XR device=]'s [=list of supported modes=] does not [=list/contain=] |mode|, [=queue a task=] to [=/resolve=] |promise| with <code>false</code> and abort these steps.
+    1. [=queue a task=] to [=/resolve=] |promise| with <code>true</code>.
   1. Return |promise|.
 
 </div>
@@ -711,8 +711,8 @@ When this method is invoked, the user agent MUST run the following steps:
   1. Let |promise| be [=a new Promise=] in the [=relevant realm=] of this {{XRSession}}.
   1. Run the following steps [=in parallel=]:
     1. [=Create a reference space=], |referenceSpace|, with the {{XRReferenceSpaceType}} |type|.
-    1. If |referenceSpace| is <code>null</code>, [=reject=] |promise| with a {{NotSupportedError}} and abort these steps.
-    1. [=/Resolve=] |promise| with |referenceSpace|.
+    1. If |referenceSpace| is <code>null</code>, [=queue a task=] to [=reject=] |promise| with a {{NotSupportedError}} and abort these steps.
+    1. [=Queue a task=] to [=/resolve=] |promise| with |referenceSpace|.
   1. Return |promise|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -2050,6 +2050,8 @@ async function onXRSessionStarted(xrSession) {
 Events {#events}
 ======
 
+The [=task source=] for all [=tasks queued|queue a task=] in this specification is the <dfn>XR task source</dfn>, unless otherwise specified.
+
 XRSessionEvent {#xrsessionevent-interface}
 --------------
 


### PR DESCRIPTION
fixes https://github.com/immersive-web/webxr/issues/1020, fixes https://github.com/immersive-web/webxr/issues/1022

I didn't update every instance of "queue a task" because both WebGL and HTML's Websocket section specify the task source used once in the document.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1032.html" title="Last updated on May 11, 2020, 10:13 PM UTC (17301e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1032/f22797e...Manishearth:17301e4.html" title="Last updated on May 11, 2020, 10:13 PM UTC (17301e4)">Diff</a>