### PR TITLE
Mark correct paragraph as definition of 'view'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1268,9 +1268,9 @@ Views {#views}
 XRView {#xrview-interface}
 ------
 
-An {{XRView}} describes a single <dfn>view</dfn> into an XR scene for a given frame.
+An {{XRView}} describes a single [=view=] into an XR scene for a given frame.
 
-Each [=view=] corresponds to a display or portion of a display used by an XR device to present imagery to the user. They are used to retrieve all the information necessary to render content that is well aligned to the [=view=]'s physical output properties, including the field of view, eye offset, and other optical properties. [=Views=] may cover overlapping regions of the user's vision. No guarantee is made about the number of [=views=] any XR device uses or their order, nor is the number of [=views=] required to be constant for the duration of an {{XRSession}}.
+A <dfn>view</dfn> corresponds to a display or portion of a display used by an XR device to present imagery to the user. They are used to retrieve all the information necessary to render content that is well aligned to the [=view=]'s physical output properties, including the field of view, eye offset, and other optical properties. [=Views=] may cover overlapping regions of the user's vision. No guarantee is made about the number of [=views=] any XR device uses or their order, nor is the number of [=views=] required to be constant for the duration of an {{XRSession}}.
 
 A [=view=] has an associated internal <dfn>view offset</dfn>, which is an {{XRRigidTransform}} describing the position and orientation of the [=view=] in the [=XRSession/viewer reference space=]'s [=coordinate system=].
 


### PR DESCRIPTION
Fixes https://github.com/immersive-web/webxr/issues/1047


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1048.html" title="Last updated on May 18, 2020, 8:27 PM UTC (3b2382d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1048/d3aa05e...Manishearth:3b2382d.html" title="Last updated on May 18, 2020, 8:27 PM UTC (3b2382d)">Diff</a>