### PR TITLE
Mention correct input frame semantics on XRInputSource/frame

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2096,7 +2096,7 @@ dictionary XRInputSourceEventInit : EventInit {
 
 The <dfn attribute for="XRInputSourceEvent">inputSource</dfn> attribute indicates the {{XRInputSource}} that generated this event.
 
-The <dfn attribute for="XRInputSourceEvent">frame</dfn> attribute is an {{XRFrame}} that corresponds with the time that the event took place. It may represent historical data. Any {{XRViewerPose}} queried from the {{XRInputSourceEvent/frame}} MUST have an empty {{XRViewerPose/views}} array.
+The <dfn attribute for="XRInputSourceEvent">frame</dfn> attribute is an {{XRFrame}} that corresponds with the time that the event took place. It may represent historical data. {{XRFrame/getViewerPose()}} MUST throw an exception when called on {{XRInputSourceEvent/frame}}.
 
 <div class="algorithm" data-algorithm="fire-input-source-event">
 


### PR DESCRIPTION
[`getViewerPose()`](https://immersive-web.github.io/webxr/#dom-xrframe-getviewerpose) step 3 will raise an `InvalidStateError` with input frames, so the line about views arrays being empty is meaningless since you can't create `XRViewerPose`s anyway.

fixes https://github.com/immersive-web/webxr/issues/1054


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1053.html" title="Last updated on May 20, 2020, 6:05 PM UTC (b29755f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1053/a059800...Manishearth:b29755f.html" title="Last updated on May 20, 2020, 6:05 PM UTC (b29755f)">Diff</a>