### PR TITLE
Properly style note

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -391,7 +391,7 @@ When this method is invoked, the user agent MUST run the following steps:
             </dl>
         1. [=/Resolve=] |promise| with |session|.
         1. [=Queue a task=] to perform the following steps:
-            NOTE: These steps ensure that initial <code>inputsourceschange</code> events occur after the initial session is resolved.
+            <div class=note>Note: These steps ensure that initial <code>inputsourceschange</code> events occur after the initial session is resolved.</div>
             1. Set |session|'s [=XRSession/promise resolved=] flag to <code>true</code>.
             1. Let |sources| be any existing input sources attached to |session|.
             1. If |sources| is non-empty, perform the following steps:


### PR DESCRIPTION
The `Note:` magic syntax doesn't work within lists


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1059.html" title="Last updated on May 22, 2020, 10:12 PM UTC (51d7dd8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1059/58b5731...Manishearth:51d7dd8.html" title="Last updated on May 22, 2020, 10:12 PM UTC (51d7dd8)">Diff</a>