### PR TITLE
Use unsigned long for rAF ids

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -581,7 +581,7 @@ enum XRVisibilityState {
   void updateRenderState(optional XRRenderStateInit state = {});
   [NewObject] Promise&lt;XRReferenceSpace&gt; requestReferenceSpace(XRReferenceSpaceType type);
 
-  long requestAnimationFrame(XRFrameRequestCallback callback);
+  unsigned long requestAnimationFrame(XRFrameRequestCallback callback);
   void cancelAnimationFrame(long handle);
 
   Promise&lt;void&gt; end();


### PR DESCRIPTION
I don't see a clear reason why we're using signed integers (long in WebIDL) right now. My proposal would be to switch to unsigned ones.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/svillar/webxr/pull/1062.html" title="Last updated on May 25, 2020, 8:22 PM UTC (cd2ee6e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1062/b86f723...svillar:cd2ee6e.html" title="Last updated on May 25, 2020, 8:22 PM UTC (cd2ee6e)">Diff</a>