### PR TITLE
added 'check the layers state' algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -910,6 +910,15 @@ When this method is invoked, the user agent MUST run the following steps:
 
 </div>
 
+<div class="algorithm" data-algorithm="check-layers-state">
+To <dfn>check the layers state</dfn> with {{XRSession/renderState}} |state|, the user agent MUST run the following steps:
+  1. If |state|'s {{XRRenderState/baseLayer}} is <code>null</code>, return <code>false</code>.
+  1. return <code>true</code>.
+
+NOTE: The <a href="https://immersive-web.github.io/layers">WebXR layers module</a> will introduce new semantics for this algorithm.
+
+</div>
+
 <div class="algorithm" data-algorithm="run-animation-frames">
 
 When an {{XRSession}} |session| receives updated [=viewer=] state for timestamp |frameTime| from the [=XRSession/XR device=], it runs an <dfn>XR animation frame</dfn>, which MUST run the following steps regardless of if the [=list of animation frame callbacks=] is empty or not:
@@ -917,7 +926,7 @@ When an {{XRSession}} |session| receives updated [=viewer=] state for timestamp 
   1. Let |now| be the [=current high resolution time=].
   1. Let |frame| be a [=new=] {{XRFrame}} with [=XRFrame/time=] |frameTime| and {{XRFrame/session}} |session| in the [=relevant realm=] of |session|.
   1. If |session|'s [=pending render state=] is not <code>null</code>, [=apply the pending render state=].
-  1. If |session|'s {{XRSession/renderState}}'s {{XRRenderState/baseLayer}} is <code>null</code>, abort these steps.
+  1. If [=check the layers state=] with |session|'s {{XRSession/renderState}} is <code>false</code>, abort these steps.
   1. If |session|'s  [=XRSession/mode=] is {{XRSessionMode/"inline"}} and |session|'s {{XRSession/renderState}}'s [=XRRenderState/output canvas=] is <code>null</code>, abort these steps.
   1. Set  |session|'s [=list of currently running animation frame callbacks=] to be |session|'s [=list of animation frame callbacks=].
   1. Set |session|'s [=list of animation frame callbacks=] to the empty list.


### PR DESCRIPTION
This change is needed to address https://github.com/immersive-web/layers/issues/143
Without this change, we can't patch the algorithm for sessions with layers.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/webxr-1/pull/1064.html" title="Last updated on May 26, 2020, 5:26 PM UTC (d43de8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1064/b315c6b...cabanier:d43de8e.html" title="Last updated on May 26, 2020, 5:26 PM UTC (d43de8e)">Diff</a>