### PR TITLE
Change document visibility check to be UA choice

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2349,7 +2349,6 @@ To determine if <dfn>poses must be limited</dfn> between two spaces, |space| and
   1. If either |space| or |baseSpace| are an {{XRBoundedReferenceSpace}} and the other space's [=native origin=]'s falls further outside the [=native bounds geometry=] than a reasonable distance determined by the user agent, return true.
   1. If either |space| or |baseSpace| are an {{XRReferenceSpace}} with a [=XRReferenceSpace/type=] of {{XRReferenceSpaceType/"local"}} or {{XRReferenceSpaceType/"local-floor"}} and the distance between the spaces' [=native origin=]'s is greater than a reasonable distance determined by the user agent, return <code>true</code>.
   1. Let |document| be |space|'s [=relevant global object=]'s [=associated document=].
-  1. If |document| is [=hidden=] return <code>true</code>.
   1. Return <code>false</code>.
 
 </div>


### PR DESCRIPTION
I'm also open to removing it entirely, there seemed to be general consensus that `visibilityState` is enough.

Fixes #1041


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1067.html" title="Last updated on May 29, 2020, 4:23 PM UTC (896e1ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1067/403f2e5...Manishearth:896e1ea.html" title="Last updated on May 29, 2020, 4:23 PM UTC (896e1ea)">Diff</a>