### PR TITLE
Use unsigned long for cancelAnimationFrame()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -582,7 +582,7 @@ enum XRVisibilityState {
   [NewObject] Promise&lt;XRReferenceSpace&gt; requestReferenceSpace(XRReferenceSpaceType type);
 
   unsigned long requestAnimationFrame(XRFrameRequestCallback callback);
-  void cancelAnimationFrame(long handle);
+  void cancelAnimationFrame(unsigned long handle);
 
   Promise&lt;void&gt; end();
 


### PR DESCRIPTION
In #1062 we moved from signed to unsigned integers in the return value of `requestAnimationFrame`. However we forgot to do the same for the cancelAnimationFrame() as it gets the handle returned by requestAnimationFrame().


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/svillar/webxr/pull/1069.html" title="Last updated on May 29, 2020, 4:14 PM UTC (2a60982)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1069/403f2e5...svillar:2a60982.html" title="Last updated on May 29, 2020, 4:14 PM UTC (2a60982)">Diff</a>