### PR TITLE
Clarify some things about native origins

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1098,7 +1098,11 @@ An {{XRSpace}} represents a virtual coordinate system with an origin that corres
 
 Each {{XRSpace}} has a <dfn for="XRSpace">session</dfn> which is set to the {{XRSession}} that created the {{XRSpace}}.
 
-Each {{XRSpace}} has a <dfn for="XRSpace">native origin</dfn> that is tracked by the [=XRSession/XR device=]'s underlying tracking system, and an <dfn for="XRSpace">effective origin</dfn>, which is the basis of the {{XRSpace}}'s <dfn for="XRSpace">coordinate system</dfn>. The transform from the effective space to the [=native origin=]'s space is defined by an <dfn for="XRSpace">origin offset</dfn>, which is an {{XRRigidTransform}} initially set to an [=identity transform=].
+Each {{XRSpace}} has a <dfn for="XRSpace">native origin</dfn> which is a position and orientation in space. The {{XRSpace}}'s [=XRSpace/native origin=] may be updated by the [=XRSession/XR device=]'s underlying tracking system, and different {{XRSpaces}} may define different semantics as to how their [=native origins=] are tracked and updated.
+
+Each {{XRSpace}} has an <dfn for="XRSpace">effective origin</dfn>, which is the basis of the {{XRSpace}}'s <dfn for="XRSpace">coordinate system</dfn>.
+
+The transform from the effective space to the [=native origin=]'s space is defined by an <dfn for="XRSpace">origin offset</dfn>, which is an {{XRRigidTransform}} initially set to an [=identity transform=]. In other words, the [=effective origin=] can be obtained by [=multiply transforms|multiplying=] [=origin offset=] and the [=native origin=].
 
 The [=effective origin=] of an {{XRSpace}} can only be observed in the coordinate system of another {{XRSpace}} as an {{XRPose}}, returned by an {{XRFrame}}'s {{XRFrame/getPose()}} method. The spatial relationship between {{XRSpace}}s MAY change between {{XRFrame}}s.
 

--- a/index.bs
+++ b/index.bs
@@ -1227,7 +1227,7 @@ The <dfn method for="XRReferenceSpace">getOffsetReferenceSpace(|originOffset|)</
       <dt> Else
       <dd> Let |offsetSpace| be a [=new=] {{XRReferenceSpace}} in the [=relevant realm=] of |base|.
     </dl>
-  1. Set |offsetSpace|'s [=native origin=] to |base|'s [=native origin=].
+  1. Set |offsetSpace|'s [=XRReferenceSpace/type=] to |base|'s [=XRReferenceSpace/type=].
   1. Set |offsetSpace|'s [=origin offset=] to the result of [=multiply transforms|multiplying=] |base|'s [=origin offset=] by |originOffset| in the [=relevant realm=] of |base|.
   1. Return |offsetSpace|.
 


### PR DESCRIPTION
This led to some confusion in https://github.com/immersive-web/anchors/issues/46.

Namely, native origins as a "type" are not some special tracked entity, rather, the object holding on to them has specal tracking behavior for updating them. Otherwise we are passing around types with spooky underspecified semantics.

This also corrects how origin offsets work, there is no point in copying the native origin, it's the _type_ which must be copied.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1071.html" title="Last updated on Jun 2, 2020, 1:06 AM UTC (0b1b51a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1071/efa3f25...Manishearth:0b1b51a.html" title="Last updated on Jun 2, 2020, 1:06 AM UTC (0b1b51a)">Diff</a>