### PR TITLE
Add text about extra views

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -30,6 +30,8 @@ spec:permissions-1;
     type:dfn; text:powerful feature
 spec:webidl;
     type:dfn; text:new
+spec:webxr-ar-module-1;
+    type:dfn; text:first-person observer view
 </pre>
 
 <pre class="anchors">
@@ -1299,6 +1301,10 @@ A [=view=] has an associated <dfn for="view">projection matrix</dfn> which is a 
 A [=view=] has an associated <dfn for="view">eye</dfn> which is an {{XREye}} describing which eye this view is expected to be shown to. If the view does not have an intrinsically associated eye (the display is monoscopic, for example) this value MUST be set to {{XREye/"none"}}.
 
 Note: Many HMDs will request that content render two [=views=], one for the left eye and one for the right, while most magic window devices will only request one [=view=], but applications should never assume a specific view configuration. For example: A magic window device may request two views if it is capable of stereo output, but may revert to requesting a single view for performance reasons if the stereo output mode is turned off. Similarly, HMDs may request more than two views to facilitate a wide field of view or displays of different pixel density.
+
+User-agents MAY choose to expose more than two [=views=] at a time, and content should be written to expect any nonzero number of elements in the [=views=] array, to support things like quad-view devices (where there are two extra low-resolution views with wider fields of view), or CAVE systems.
+
+Note: We expect there to be a significant amount of content that does not work well with this, so user agents should be careful when choosing to expose extra [=views=]. It may be better in some cases to ask content to explicitly signal support for an extra style of [=view=], as is the case with [=first-person observer views=].
 
 <pre class="idl">
 enum XREye {


### PR DESCRIPTION
I chose to write the text such that user-agents are allowed to expose additional views and content is expected to handle it, but we recommend that user-agents don't do this.


Depends on https://github.com/immersive-web/webxr-ar-module/pull/57

Fixes https://github.com/immersive-web/webxr/issues/1045

cc @cabanier @thetuvix


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1080.html" title="Last updated on Jun 11, 2020, 7:55 PM UTC (33bcfe7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1080/ed58334...Manishearth:33bcfe7.html" title="Last updated on Jun 11, 2020, 7:55 PM UTC (33bcfe7)">Diff</a>