### PR TITLE
Add feature for secondary views

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1357,7 +1357,7 @@ Additional Views {#additional-views}
 
 While most devices will either have a single "mono" [=view=] or two "stereo" [=views=], it is possible for devices to have <dfn>additional views</dfn> which do not fall into these categories.
 
-<div class="example">For example, there can be a [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolution and fields of view. There can also be CAVE systems which have many, many views surrounding the user.</div>
+<div class="example">For example, there can be a [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolution and fields of view. There can also be CAVE systems which have many views surrounding the user.</div>
 
 While content should be written to assume that there may be any number of views, we expect a significant amount of content to make incorrect assumptions about the {{XRViewerPose/views}} array and thus break when presented with more than two views.
 

--- a/index.bs
+++ b/index.bs
@@ -1355,14 +1355,14 @@ To <dfn for="XRView">obtain the projection matrix</dfn> for a given {{XRView}} |
 Primary and Secondary Views {#primary-and-secondary-views}
 ----------
 
-A [=view=] is a <dfn>primary view</dfn> if rendering to it is necessary for the immersive experience.
+A [=view=] is a <dfn>primary view</dfn> when rendering to it is necessary for an immersive experience.
 
-A [=view=] is a <dfn>secondary view</dfn> if it is possible for content to choose to not render to it and still produce a working immersive experience. If content chooses to not render to these views, the user-agent MAY reconstruct them via reprojection.
+A [=view=] is a <dfn>secondary view</dfn> when it is possible for content to choose to not render to it and still produce a working immersive experience. When content chooses to not render to these views, the user-agent MAY be able to reconstruct them via reprojection.
 
 <div class="example">
-Examples of [=primary views=] include the main mono view of a handheld AR session, the main two stereo views of headworn AR/VR sessions, or all of the wall views of a CAVE session.
+Examples of [=primary views=] include the main mono view for a handheld AR session, the main two stereo views for headworn AR/VR sessions, or all of the wall views for a CAVE session.
 
-Examples of [=secondary views=] include the [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolutions or fields of view.
+Examples of [=secondary views=] include the [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolution and fields of view.
 
 </div>
 
@@ -1372,13 +1372,13 @@ While content should be written to assume that there may be any number of views,
 Because user-agents may have the ability to use mechanisms like reprojection to render to these [=secondary views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=secondary views=] itself and content that is either oblivious to the existence of such [=secondary views=] or does not wish to deal with them.
 </div>
 
-User agents that expose [=secondary views=] MUST support a "<dfn for="secondary views">secondary-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
+To provide for this, user-agents that expose [=secondary views=] MUST support an "<dfn for="secondary views">secondary-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
 
  - Handle any nonzero number of [=views=] in the {{XRViewerPose/views}} array.
  - Handle the existence of multiple [=views=] that have the same [=view/eye=].
  - Handle the size of the {{XRViewerPose/views}} array changing from frame to frame. <span class=note>This can happen when video capture is enabled, for example</span>
 
-When "[=secondary views/secondary-views=]" is enabled, the user agent MAY surface any [=secondary views=] the device supports to the {{XRSession}}. The user agent MUST NOT use reprojection to reconstruct [=secondary views=] in such a case, but instead rely on whatever the content decides to render.
+When "[=secondary views/secondary-views=]" is enabled, the user-agent MAY surface any [=secondary views=] the device supports to the {{XRSession}}, when necessary. The user-agent MUST NOT use reprojection to reconstruct [=secondary views=] in such a case, and instead rely on whatever the content decides to render.
 
 Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=secondary views/secondary-views=]" to ensure maximum compatibility.
 
@@ -1386,6 +1386,7 @@ If [=secondary views=] have lower underlying frame rates, the {{XRSession}} MAY 
 
  - Lower the overall frame rate of the application while the [=secondary views=] are active.
  - Surface [=secondary views=] in the {{XRViewerPose/views}} array only for some of the frames. Implementations doing this SHOULD NOT have frames where the [=primary views=] are not present.
+ - Silently discard rendered content for [=secondary views=] during some of the frames.
 
 XRViewport {#xrviewport-interface}
 ----------

--- a/index.bs
+++ b/index.bs
@@ -1378,7 +1378,7 @@ User agents that expose [=secondary views=] MUST support a "<dfn for="secondary 
  - Handle the existence of multiple [=views=] that have the same [=view/eye=].
  - Handle the size of the {{XRViewerPose/views}} array changing from frame to frame. <span class=note>This can happen when video capture is enabled, for example</span>
 
-When "[=secondary views/secondary-views=]" is enabled, the user-agent MAY surface any [=secondary views=] the device supports to the {{XRSession}}, when necessary. The user-agent MUST NOT use reprojection to reconstruct [=secondary views=] in such a case, and instead rely on whatever the content decides to render.
+When "[=secondary views/secondary-views=]" is enabled, the user agent MAY surface any [=secondary views=] the device supports to the {{XRSession}}. The user agent MUST NOT use reprojection to reconstruct [=secondary views=] in such a case, but instead rely on whatever the content decides to render.
 
 Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=secondary views/secondary-views=]" to ensure maximum compatibility.
 

--- a/index.bs
+++ b/index.bs
@@ -1357,7 +1357,7 @@ Primary and Secondary Views {#primary-and-secondary-views}
 
 A [=view=] is a <dfn>primary view</dfn> if rendering to it is necessary for the immersive experience.
 
-A [=view=] is a <dfn>secondary view</dfn> when it is possible for content to choose to not render to it and still produce a working immersive experience. When content chooses to not render to these views, the user-agent MAY be able to reconstruct them via reprojection.
+A [=view=] is a <dfn>secondary view</dfn> if it is possible for content to choose to not render to it and still produce a working immersive experience. If content chooses to not render to these views, the user-agent MAY reconstruct them via reprojection.
 
 <div class="example">
 Examples of [=primary views=] include the main mono view for a handheld AR session, the main two stereo views for headworn AR/VR sessions, or all of the wall views for a CAVE session.

--- a/index.bs
+++ b/index.bs
@@ -1360,7 +1360,7 @@ A [=view=] is a <dfn>primary view</dfn> if rendering to it is necessary for the 
 A [=view=] is a <dfn>secondary view</dfn> if it is possible for content to choose to not render to it and still produce a working immersive experience. If content chooses to not render to these views, the user-agent MAY reconstruct them via reprojection.
 
 <div class="example">
-Examples of [=primary views=] include the main mono view for a handheld AR session, the main two stereo views for headworn AR/VR sessions, or all of the wall views for a CAVE session.
+Examples of [=primary views=] include the main mono view of a handheld AR session, the main two stereo views of headworn AR/VR sessions, or all of the wall views of a CAVE session.
 
 Examples of [=secondary views=] include the [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolution and fields of view.
 

--- a/index.bs
+++ b/index.bs
@@ -1352,36 +1352,40 @@ To <dfn for="XRView">obtain the projection matrix</dfn> for a given {{XRView}} |
 </div>
 
 
-Additional Views {#additional-views-support}
+Primary and Secondary Views {#primary-and-secondary-views}
 ----------
 
-While most devices will either have a single "mono" [=view=] or two "stereo" [=views=], it is possible for devices to have <dfn>additional views</dfn> which do not fall into these categories.
+A [=view=] is a <dfn>primary view</dfn> when rendering to it is necessary for an immersive experience.
 
-<div class="example">For example, there can be a [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolution and fields of view. There can also be CAVE systems which have many views surrounding the user.</div>
+A [=view=] is a <dfn>secondary view</dfn> when it is possible for content to choose to not render to it and still produce a working immersive experience. When content chooses to not render to these views, the user-agent MAY be able to reconstruct them via reprojection.
+
+<div class="example">
+Examples of [=primary views=] include the main mono view for a handheld AR session, the main two stereo views for headworn AR/VR sessions, or all of the wall views for a CAVE session.
+
+Examples of [=secondary views=] include the [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolution and fields of view.
+
+</div>
 
 <div class=note>
 While content should be written to assume that there may be any number of views, we expect a significant amount of content to make incorrect assumptions about the {{XRViewerPose/views}} array and thus break when presented with more than two views.
 
-Because user-agents may have the ability to use mechanisms like reprojection to render to these [=additional views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=additional views=] itself and content that is either oblivious to the existence of such [=additional views=] or does not wish to deal with them.
+Because user-agents may have the ability to use mechanisms like reprojection to render to these [=secondary views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=secondary views=] itself and content that is either oblivious to the existence of such [=secondary views=] or does not wish to deal with them.
 </div>
 
-To provide for this, user-agents that expose more than 2 views MUST support an "<dfn for="additional views">additional-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
+To provide for this, user-agents that expose [=secondary views=] MUST support an "<dfn for="secondary views">secondary-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
 
  - Handle any nonzero number of [=views=] in the {{XRViewerPose/views}} array.
  - Handle the existence of multiple [=views=] that have the same [=view/eye=].
  - Handle the size of the {{XRViewerPose/views}} array changing from frame to frame. <span class=note>This can happen when video capture is enabled, for example</span>
 
-When "[=additional views/additional-views=]" is enabled, the user-agent MAY surface any [=additional views=] the device supports to the {{XRSession}}, when necessary.
+When "[=secondary views/secondary-views=]" is enabled, the user-agent MAY surface any [=secondary views=] the device supports to the {{XRSession}}, when necessary. The user-agent MUST NOT use reprojection to reconstruct [=secondary views=] in such a case, and instead rely on whatever the content decides to render.
 
-Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=additional views/additional-views=]" to ensure maximum compatibility.
+Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=secondary views/secondary-views=]" to ensure maximum compatibility.
 
-For devices like CAVE systems where the user-agent is not able to accept stereo views and reproject to simulate the [=additional views=], the user-agent MAY choose to surface all [=views=] unconditionally, or it alternatively MAY choose to reject [=immersive sessions=] created without "[=additional views/additional-views=]" enabled.
+If [=secondary views=] have lower underlying frame rates, the {{XRSession}} MAY choose to do one or more of the following:
 
-
-If [=additional views=] have lower underlying frame rates, the {{XRSession}} MAY choose to do one or more of the following:
-
- - Lower the overall frame rate of the application while the [=additional views=] are active.
- - Surface [=additional views=] in the {{XRViewerPose/views}} array only for some of the frames. Implementations doing this SHOULD NOT have frames where the "primary" (non-[=additional views|additional=]) views are not present.
+ - Lower the overall frame rate of the application while the [=secondary views=] are active.
+ - Surface [=secondary views=] in the {{XRViewerPose/views}} array only for some of the frames. Implementations doing this SHOULD NOT have frames where the [=primary views=] are not present.
 
 XRViewport {#xrviewport-interface}
 ----------

--- a/index.bs
+++ b/index.bs
@@ -30,6 +30,8 @@ spec:permissions-1;
     type:dfn; text:powerful feature
 spec:webidl;
     type:dfn; text:new
+spec:webxr-ar-module-1;
+    type:dfn; text:first-person observer view
 </pre>
 
 <pre class="anchors">
@@ -1349,6 +1351,31 @@ To <dfn for="XRView">obtain the projection matrix</dfn> for a given {{XRView}} |
 
 </div>
 
+
+Additional Views {#additional-views}
+----------
+
+While most devices will either have a single "mono" [=view=] or two "stereo" [=views=], it is possible for devices to have <dfn>additional views</dfn> which do not fall into these categories.
+
+<div class="example">For example, there can be a [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolution and fields of view. There can also be CAVE systems which have many, many views surrounding the user.</div>
+
+While content should be written to assume that there may be any number of views, we expect a significant amount of content to make incorrect assumptions about the {{XRViewerPose/views}} array and thus break when presented with more than two views.
+
+Because user-agents may have the ability to use mechanisms like reprojection to render to these [=additional views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=additional views=] itself and content that is either oblivious to the existence of such [=additional views=] or does not wish to deal with them.
+
+To provide for this, user-agents MAY support an <dfn>additional-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
+
+ - Handle any nonzero number of [=views=] in the {{XRViewerPose/views}} array.
+ - Handle the existence of multiple [=views=] that have the same [=view/eye=].
+ - Handle the size of the {{XRViewerPose/views}} array changing from frame to frame (e.g. when video capture is enabled).
+
+When "[=additional-views=]" is enabled, the user-agent SHOULD surface any [=additional views=] the device supports to the {{XRSession}}, when necessary.
+
+For devices like CAVE systems where the user-agent cannot simply accept stereo views and reproject its way to the [=additional views=], the user-agent MAY choose surface all [=views=] unconditionally (hoping that the content is able to handle it), or it alternatively MAY choose to reject [=immersive sessions=] created without "[=additional-views=]" enabled.
+
+Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=additional-views=]" to ensure maximum compatibility.
+
+{{XRSession}}s that are supporting [=additional views=] must ensure that their [=recommended WebGL framebuffer resolution=] is large enough to fit all [=views=] that may appear during a session. If [=additional views=] have lower underlying frame rates, the {{XRSession}} MAY choose to only surface them in the {{XRViewerPose/views}} array every other frame or at whatever rate it wishes
 
 XRViewport {#xrviewport-interface}
 ----------

--- a/index.bs
+++ b/index.bs
@@ -1379,7 +1379,7 @@ For devices like CAVE systems where the user-agent is not able to accept stereo 
 If [=additional views=] have lower underlying frame rates, the {{XRSession}} MAY choose to either:
 
  - Lower the overall frame rate of the application while the [=additional views=] are active.
- - Surface them in the {{XRViewerPose/views}} array only for some of the frames.
+ - Surface [=additional views=] in the {{XRViewerPose/views}} array only for some of the frames.
 
 XRViewport {#xrviewport-interface}
 ----------

--- a/index.bs
+++ b/index.bs
@@ -1372,7 +1372,7 @@ While content should be written to assume that there may be any number of views,
 Because user-agents may have the ability to use mechanisms like reprojection to render to these [=secondary views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=secondary views=] itself and content that is either oblivious to the existence of such [=secondary views=] or does not wish to deal with them.
 </div>
 
-To provide for this, user-agents that expose [=secondary views=] MUST support an "<dfn for="secondary views">secondary-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
+User agents that expose [=secondary views=] MUST support a "<dfn for="secondary views">secondary-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
 
  - Handle any nonzero number of [=views=] in the {{XRViewerPose/views}} array.
  - Handle the existence of multiple [=views=] that have the same [=view/eye=].

--- a/index.bs
+++ b/index.bs
@@ -1359,9 +1359,11 @@ While most devices will either have a single "mono" [=view=] or two "stereo" [=v
 
 <div class="example">For example, there can be a [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolution and fields of view. There can also be CAVE systems which have many views surrounding the user.</div>
 
+<div class=note>
 While content should be written to assume that there may be any number of views, we expect a significant amount of content to make incorrect assumptions about the {{XRViewerPose/views}} array and thus break when presented with more than two views.
 
-<span class=informative>Because user-agents may have the ability to use mechanisms like reprojection to render to these [=additional views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=additional views=] itself and content that is either oblivious to the existence of such [=additional views=] or does not wish to deal with them.</span>
+Because user-agents may have the ability to use mechanisms like reprojection to render to these [=additional views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=additional views=] itself and content that is either oblivious to the existence of such [=additional views=] or does not wish to deal with them.
+</div>
 
 To provide for this, user-agents that expose more than 2 views MUST support an "<dfn for="additional views">additional-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
 

--- a/index.bs
+++ b/index.bs
@@ -1355,7 +1355,7 @@ To <dfn for="XRView">obtain the projection matrix</dfn> for a given {{XRView}} |
 Primary and Secondary Views {#primary-and-secondary-views}
 ----------
 
-A [=view=] is a <dfn>primary view</dfn> when rendering to it is necessary for an immersive experience.
+A [=view=] is a <dfn>primary view</dfn> if rendering to it is necessary for the immersive experience.
 
 A [=view=] is a <dfn>secondary view</dfn> when it is possible for content to choose to not render to it and still produce a working immersive experience. When content chooses to not render to these views, the user-agent MAY be able to reconstruct them via reprojection.
 

--- a/index.bs
+++ b/index.bs
@@ -1352,7 +1352,7 @@ To <dfn for="XRView">obtain the projection matrix</dfn> for a given {{XRView}} |
 </div>
 
 
-Additional Views {#additional-views}
+Additional Views {#additional-views-support}
 ----------
 
 While most devices will either have a single "mono" [=view=] or two "stereo" [=views=], it is possible for devices to have <dfn>additional views</dfn> which do not fall into these categories.
@@ -1361,9 +1361,9 @@ While most devices will either have a single "mono" [=view=] or two "stereo" [=v
 
 While content should be written to assume that there may be any number of views, we expect a significant amount of content to make incorrect assumptions about the {{XRViewerPose/views}} array and thus break when presented with more than two views.
 
-Because user-agents may have the ability to use mechanisms like reprojection to render to these [=additional views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=additional views=] itself and content that is either oblivious to the existence of such [=additional views=] or does not wish to deal with them.
+<span class=informative>Because user-agents may have the ability to use mechanisms like reprojection to render to these [=additional views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=additional views=] itself and content that is either oblivious to the existence of such [=additional views=] or does not wish to deal with them.</span>
 
-To provide for this, user-agents MAY support an <dfn>additional-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
+To provide for this, user-agents MAY support an "<dfn>additional-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
 
  - Handle any nonzero number of [=views=] in the {{XRViewerPose/views}} array.
  - Handle the existence of multiple [=views=] that have the same [=view/eye=].

--- a/index.bs
+++ b/index.bs
@@ -1369,7 +1369,7 @@ To provide for this, user-agents MAY support an "<dfn>additional-views</dfn>" [=
  - Handle the existence of multiple [=views=] that have the same [=view/eye=].
  - Handle the size of the {{XRViewerPose/views}} array changing from frame to frame. <span class=note>This can happen when video capture is enabled, for example</span>
 
-When "[=additional-views=]" is enabled, the user-agent SHOULD surface any [=additional views=] the device supports to the {{XRSession}}, when necessary.
+When "[=additional-views=]" is enabled, the user-agent MAY surface any [=additional views=] the device supports to the {{XRSession}}, when necessary.
 
 Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=additional-views=]" to ensure maximum compatibility.
 

--- a/index.bs
+++ b/index.bs
@@ -1363,17 +1363,17 @@ While content should be written to assume that there may be any number of views,
 
 <span class=informative>Because user-agents may have the ability to use mechanisms like reprojection to render to these [=additional views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=additional views=] itself and content that is either oblivious to the existence of such [=additional views=] or does not wish to deal with them.</span>
 
-To provide for this, user-agents that expose more than 2 views MUST support an "<dfn>additional-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
+To provide for this, user-agents that expose more than 2 views MUST support an "<dfn for="additional views">additional-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
 
  - Handle any nonzero number of [=views=] in the {{XRViewerPose/views}} array.
  - Handle the existence of multiple [=views=] that have the same [=view/eye=].
  - Handle the size of the {{XRViewerPose/views}} array changing from frame to frame. <span class=note>This can happen when video capture is enabled, for example</span>
 
-When "[=additional-views=]" is enabled, the user-agent MAY surface any [=additional views=] the device supports to the {{XRSession}}, when necessary.
+When "[=additional views/additional-views=]" is enabled, the user-agent MAY surface any [=additional views=] the device supports to the {{XRSession}}, when necessary.
 
-Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=additional-views=]" to ensure maximum compatibility.
+Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=additional views/additional-views=]" to ensure maximum compatibility.
 
-For devices like CAVE systems where the user-agent is not able to accept stereo views and reproject to simulate the [=additional views=], the user-agent MAY choose surface all [=views=] unconditionally, or it alternatively MAY choose to reject [=immersive sessions=] created without "[=additional-views=]" enabled.
+For devices like CAVE systems where the user-agent is not able to accept stereo views and reproject to simulate the [=additional views=], the user-agent MAY choose surface all [=views=] unconditionally, or it alternatively MAY choose to reject [=immersive sessions=] created without "[=additional views/additional-views=]" enabled.
 
 
 If [=additional views=] have lower underlying frame rates, the {{XRSession}} MAY choose to do one or more of the following:

--- a/index.bs
+++ b/index.bs
@@ -1362,7 +1362,7 @@ A [=view=] is a <dfn>secondary view</dfn> if it is possible for content to choos
 <div class="example">
 Examples of [=primary views=] include the main mono view of a handheld AR session, the main two stereo views of headworn AR/VR sessions, or all of the wall views of a CAVE session.
 
-Examples of [=secondary views=] include the [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolution and fields of view.
+Examples of [=secondary views=] include the [=first-person observer view=] used for video capture, or "quad views" where there are two views per eye with differing resolutions or fields of view.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1376,10 +1376,10 @@ Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=a
 For devices like CAVE systems where the user-agent is not able to accept stereo views and reproject to simulate the [=additional views=], the user-agent MAY choose surface all [=views=] unconditionally, or it alternatively MAY choose to reject [=immersive sessions=] created without "[=additional-views=]" enabled.
 
 
-If [=additional views=] have lower underlying frame rates, the {{XRSession}} MAY choose to either:
+If [=additional views=] have lower underlying frame rates, the {{XRSession}} MAY choose to do one or more of the following:
 
  - Lower the overall frame rate of the application while the [=additional views=] are active.
- - Surface [=additional views=] in the {{XRViewerPose/views}} array only for some of the frames.
+ - Surface [=additional views=] in the {{XRViewerPose/views}} array only for some of the frames. Implementations doing this SHOULD NOT have frames where the "primary" (non-[=additional views|additional=]) views are not present.
 
 XRViewport {#xrviewport-interface}
 ----------

--- a/index.bs
+++ b/index.bs
@@ -1367,15 +1367,19 @@ To provide for this, user-agents MAY support an "<dfn>additional-views</dfn>" [=
 
  - Handle any nonzero number of [=views=] in the {{XRViewerPose/views}} array.
  - Handle the existence of multiple [=views=] that have the same [=view/eye=].
- - Handle the size of the {{XRViewerPose/views}} array changing from frame to frame.
+ - Handle the size of the {{XRViewerPose/views}} array changing from frame to frame. <span class=note>This can happen when video capture is enabled, for example</span>
 
 When "[=additional-views=]" is enabled, the user-agent SHOULD surface any [=additional views=] the device supports to the {{XRSession}}, when necessary.
 
-For devices like CAVE systems where the user-agent cannot simply accept stereo views and reproject its way to the [=additional views=], the user-agent MAY choose surface all [=views=] unconditionally (hoping that the content is able to handle it), or it alternatively MAY choose to reject [=immersive sessions=] created without "[=additional-views=]" enabled.
-
 Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=additional-views=]" to ensure maximum compatibility.
 
-{{XRSession}}s that are supporting [=additional views=] must ensure that their [=recommended WebGL framebuffer resolution=] is large enough to fit all [=views=] that may appear during a session. If [=additional views=] have lower underlying frame rates, the {{XRSession}} MAY choose to only surface them in the {{XRViewerPose/views}} array every other frame or at whatever rate it wishes
+For devices like CAVE systems where the user-agent is not able to accept stereo views and reproject to simulate the [=additional views=], the user-agent MAY choose surface all [=views=] unconditionally, or it alternatively MAY choose to reject [=immersive sessions=] created without "[=additional-views=]" enabled.
+
+
+If [=additional views=] have lower underlying frame rates, the {{XRSession}} MAY choose to either:
+
+ - Lower the overall frame rate of the application while the [=additional views=] are active.
+ - Surface them in the {{XRViewerPose/views}} array only for some of the frames.
 
 XRViewport {#xrviewport-interface}
 ----------

--- a/index.bs
+++ b/index.bs
@@ -1367,7 +1367,7 @@ To provide for this, user-agents MAY support an <dfn>additional-views</dfn>" [=f
 
  - Handle any nonzero number of [=views=] in the {{XRViewerPose/views}} array.
  - Handle the existence of multiple [=views=] that have the same [=view/eye=].
- - Handle the size of the {{XRViewerPose/views}} array changing from frame to frame (e.g. when video capture is enabled).
+ - Handle the size of the {{XRViewerPose/views}} array changing from frame to frame.
 
 When "[=additional-views=]" is enabled, the user-agent SHOULD surface any [=additional views=] the device supports to the {{XRSession}}, when necessary.
 

--- a/index.bs
+++ b/index.bs
@@ -1363,7 +1363,7 @@ While content should be written to assume that there may be any number of views,
 
 <span class=informative>Because user-agents may have the ability to use mechanisms like reprojection to render to these [=additional views=] in lieu of the content, it is desirable to be able to distinguish between content that plans on handling these [=additional views=] itself and content that is either oblivious to the existence of such [=additional views=] or does not wish to deal with them.</span>
 
-To provide for this, user-agents MAY support an "<dfn>additional-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
+To provide for this, user-agents that expose more than 2 views MUST support an "<dfn>additional-views</dfn>" [=feature descriptor=] as a hint. Content enabling this feature is expected to:
 
  - Handle any nonzero number of [=views=] in the {{XRViewerPose/views}} array.
  - Handle the existence of multiple [=views=] that have the same [=view/eye=].

--- a/index.bs
+++ b/index.bs
@@ -1375,7 +1375,7 @@ When "[=additional views/additional-views=]" is enabled, the user-agent MAY surf
 
 Note: We recommend content use {{XRSessionInit/optionalFeatures}} to enable "[=additional views/additional-views=]" to ensure maximum compatibility.
 
-For devices like CAVE systems where the user-agent is not able to accept stereo views and reproject to simulate the [=additional views=], the user-agent MAY choose surface all [=views=] unconditionally, or it alternatively MAY choose to reject [=immersive sessions=] created without "[=additional views/additional-views=]" enabled.
+For devices like CAVE systems where the user-agent is not able to accept stereo views and reproject to simulate the [=additional views=], the user-agent MAY choose to surface all [=views=] unconditionally, or it alternatively MAY choose to reject [=immersive sessions=] created without "[=additional views/additional-views=]" enabled.
 
 
 If [=additional views=] have lower underlying frame rates, the {{XRSession}} MAY choose to do one or more of the following:


### PR DESCRIPTION
Alternate to  #1080

This PR adds an additional-views feature that can be used as a hint that the content is expecting additional views.

Related: immersive-web/webxr-ar-module#57

Fixes #1045