### PR TITLE
Allow caching various objects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1049,8 +1049,14 @@ When this method is invoked, the user agent MUST run the following steps:
   1. [=Populate the pose=] of |session|'s [=XRSession/viewer reference space=] in |referenceSpace| at the time represented by |frame| into |pose|, with <code>force emulation</code> set to <code>true</code>.
   1. If |pose| is <code>null</code> return <code>null</code>.
   1. Let |xrviews| be an empty [=/list=].
-  1. For each [=view=] |view| in the [=XRSession/viewer reference space/list of views=] on the[=XRSession/viewer reference space=] of {{XRFrame/session}}, perform the following steps:
-      1. Let |xrview| be a new {{XRView}} object in the [=relevant realm=] of |session|.
+  1. For each [=view=] |view| in the [=XRSession/viewer reference space/list of views=] on the [=XRSession/viewer reference space=] of {{XRFrame/session}}, perform the following steps:
+      1. Initialize |xrview| as follows:
+        <dl class="switch">
+          <dt>If an {{XRView}} object has been constructed for the same |view| on {{XRFrame/session}}, the user agent MAY:</dt>
+          <dd>Let |xrview| be the same {{XRView}} object.</dd>
+          <dt>Otherwise:</dt>
+          <dd>Let |xrview| be a [=new=] {{XRView}} object in the [=relevant realm=] of |session|.</dd>
+        </dl>
       1. Initialize |xrview|'s [=XRView/underlying view=] to |view|.
       1. Initialize |xrview|'s {{XRView/eye}} to |view|'s [=view/eye=].
       1. Initialize |xrview|'s [=XRView/frame=] to |frame|.

--- a/index.bs
+++ b/index.bs
@@ -938,7 +938,13 @@ NOTE: The <a href="https://immersive-web.github.io/layers">WebXR layers module</
 When an {{XRSession}} |session| receives updated [=viewer=] state for timestamp |frameTime| from the [=XRSession/XR device=], it runs an <dfn>XR animation frame</dfn>, which MUST run the following steps regardless of if the [=list of animation frame callbacks=] is empty or not:
 
   1. Let |now| be the [=current high resolution time=].
-  1. Let |frame| be a [=new=] {{XRFrame}} with [=XRFrame/time=] |frameTime| and {{XRFrame/session}} |session| in the [=relevant realm=] of |session|.
+  1. Initialize |frame| as follows:
+    <dl class="switch">
+      <dt>If |session| has previously run an [=XR animation frame=], the user agent MAY:</dt>
+      <dd>Let |frame| be the same {{XRFrame}} object created by the earlier [=XR animation frame=]</dd>
+      <dt>Otherwise:</dt>
+      <dd>Let |frame| be a [=new=] {{XRFrame}} with [=XRFrame/time=] |frameTime| and {{XRFrame/session}} |session| in the [=relevant realm=] of |session|.</dd>
+    </dl>
   1. If |session|'s [=pending render state=] is not <code>null</code>, [=apply the pending render state=].
   1. If [=check the layers state=] with |session|'s {{XRSession/renderState}} is <code>false</code>, abort these steps.
   1. If |session|'s  [=XRSession/mode=] is {{XRSessionMode/"inline"}} and |session|'s {{XRSession/renderState}}'s [=XRRenderState/output canvas=] is <code>null</code>, abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -1051,7 +1051,13 @@ When this method is invoked, the user agent MUST run the following steps:
   1. Let |frame| be [=this=].
   1. Let |session| be |frame|'s {{XRFrame/session}} object.
   1. If |frame|'s [=animationFrame=] boolean is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
-  1. Let |pose| be a [=new=] {{XRViewerPose}} object in the [=relevant realm=] of |session|.
+  1. Initialize |pose| as follows:
+    <dl class="switch">
+      <dt>If {{XRFrame/getViewerPose()}} was called on a previous {{XRFrame}} on the same {{XRFrame/session}} with the same |referenceSpace|, the user agent MAY:</dt>
+      <dd>Let |pose| be the same {{XRViewerPose}} object returned by the earlier call to {{XRFrame/getViewerPose()}}</dd>
+      <dt>Otherwise:</dt>
+      <dd>Let |pose| be a [=new=] {{XRViewerPose}} object in the [=relevant realm=] of |session|.</dd>
+    </dl>
   1. [=Populate the pose=] of |session|'s [=XRSession/viewer reference space=] in |referenceSpace| at the time represented by |frame| into |pose|, with <code>force emulation</code> set to <code>true</code>.
   1. If |pose| is <code>null</code> return <code>null</code>.
   1. Let |xrviews| be an empty [=/list=].

--- a/index.bs
+++ b/index.bs
@@ -1087,7 +1087,13 @@ The <dfn method for="XRFrame">getPose(|space|, |baseSpace|)</dfn> method provide
 When this method is invoked, the user agent MUST run the following steps:
 
   1. Let |frame| be [=this=].
-  1. Let |pose| be a [=new=] {{XRPose}} object in the [=relevant realm=] of |frame|.
+  1. Initialize |pose| as follows:
+    <dl class="switch">
+      <dt>If [=XRFrame/animationFrame=] is <code>true</code> {{XRFrame/getPose()}} was called on a previous {{XRFrame}} with [=XRFrame/animationFrame=] <code>true</code> on the same {{XRFrame/session}} with the same |space| and |baseSpace|, the user agent MAY:</dt>
+      <dd>Let |pose| be the same {{XRPose}} object returned by the earlier call to {{XRFrame/getPose()}}</dd>
+      <dt>Otherwise:</dt>
+      <dd>Let |pose| be a [=new=] {{XRPose}} object in the [=relevant realm=] of |frame|.</dd>
+    </dl>
   1. [=Populate the pose=] of |space| in |baseSpace| at the time represented by |frame| into |pose|.
   1. Return |pose|.
 

--- a/index.bs
+++ b/index.bs
@@ -1921,7 +1921,13 @@ The <dfn method for="XRWebGLLayer">getViewport(|view|)</dfn> method, when invoke
   1. If |frame|'s {{XRFrame/session}} is not equal to |layer|'s [=XRWebGLLayer/session=], throw an {{InvalidStateError}} and abort these steps.
   1. If |frame|'s [=XRFrame/active=] boolean is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
   1. Let |glViewport| be the [=WebGL viewport=] from the [=list of viewports=] associated with |view|.
-  1. Let |viewport| be a [=new=] {{XRViewport}} in the [=relevant realm=] of |layer|'s [=XRWebGLLayer/session=].
+  1. Initialize |viewport| as follows:
+    <dl class="switch">
+      <dt>If {{XRWebGLLayer/getViewport()}} was called previously with a |view| corresponding to the same underlying [=view=], the user agent MAY:</dt>
+      <dd>Let |viewport| be the same {{XRViewport}} object returned by the earlier call to {{XRWebGLLayer/getViewport()}}</dd>
+      <dt>Otherwise:</dt>
+      <dd>Let |viewport| be a [=new=] {{XRViewport}} in the [=relevant realm=] of |layer|'s [=XRWebGLLayer/session=].</dd>
+    </dl>
   1. Initialize |viewport|'s {{XRViewport/x}} to |glViewport|'s <code>x</code> component.
   1. Initialize |viewport|'s {{XRViewport/y}} to |glViewport|'s <code>y</code> component.
   1. Initialize |viewport|'s {{XRViewport/width}} to |glViewport|'s <code>width</code>.


### PR DESCRIPTION
Fixes #1010


This allows the session to cache:

 - XRVieweports for the same view
 - XRViews for the same view
 - XRFrames for animation frames only
 - XRViewerPoses for the same reference space
 - XRPoses for the same space combination, *provided the frame is an animation frame*


The restriction of cache frames being animation frames is there to make it possible to "hold on" to input poses during select events.

cc @asajeffrey @MortimerGoro @cabanier