### PR TITLE
Allow caching various objects (take 2)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1959,7 +1959,13 @@ The <dfn method for="XRWebGLLayer">getViewport(|view|)</dfn> method, when invoke
   1. If |frame|'s {{XRFrame/session}} is not equal to |layer|'s [=XRWebGLLayer/session=], throw an {{InvalidStateError}} and abort these steps.
   1. If |frame|'s [=XRFrame/active=] boolean is <code>false</code>, throw an {{InvalidStateError}} and abort these steps.
   1. Let |glViewport| be the [=WebGL viewport=] from the [=list of viewports=] associated with |view|.
-  1. Let |viewport| be a [=new=] {{XRViewport}} in the [=relevant realm=] of |layer|'s [=XRWebGLLayer/session=].
+  1. Initialize |viewport| as follows:
+    <dl class="switch">
+      <dt>If a |view| with the same underlying [=view=] has been passed to a getViewport() call previously, and |glViewport| has not changed since then, the user agent MUST:</dt>
+      <dd>Let |viewport| be the same {{XRViewport}} object returned by the earlier call to {{XRWebGLLayer/getViewport()}}</dd>
+      <dt>Otherwise:</dt>
+      <dd>Let |viewport| be a [=new=] {{XRViewport}} in the [=relevant realm=] of |layer|'s [=XRWebGLLayer/session=].</dd>
+    </dl>
   1. Initialize |viewport|'s {{XRViewport/x}} to |glViewport|'s <code>x</code> component.
   1. Initialize |viewport|'s {{XRViewport/y}} to |glViewport|'s <code>y</code> component.
   1. Initialize |viewport|'s {{XRViewport/width}} to |glViewport|'s <code>width</code>.

--- a/index.bs
+++ b/index.bs
@@ -940,7 +940,13 @@ NOTE: The <a href="https://immersive-web.github.io/layers">WebXR layers module</
 When an {{XRSession}} |session| receives updated [=viewer=] state for timestamp |frameTime| from the [=XRSession/XR device=], it runs an <dfn>XR animation frame</dfn>, which MUST run the following steps regardless of if the [=list of animation frame callbacks=] is empty or not:
 
   1. Let |now| be the [=current high resolution time=].
-  1. Let |frame| be a [=new=] {{XRFrame}} with [=XRFrame/time=] |frameTime| and {{XRFrame/session}} |session| in the [=relevant realm=] of |session|.
+  1. Initialize |frame| as follows:
+    <dl class="switch">
+      <dt>If |session| has previously run an [=XR animation frame=], the user agent MUST:</dt>
+      <dd>Let |frame| be the same {{XRFrame}} object created by the earlier [=XR animation frame=]</dd>
+      <dt>Otherwise:</dt>
+      <dd>Let |frame| be a [=new=] {{XRFrame}} with [=XRFrame/time=] |frameTime| and {{XRFrame/session}} |session| in the [=relevant realm=] of |session|.</dd>
+    </dl>
   1. If |session|'s [=pending render state=] is not <code>null</code>, [=apply the pending render state=].
   1. If [=check the layers state=] with |session|'s {{XRSession/renderState}} is <code>false</code>, abort these steps.
   1. If |session|'s  [=XRSession/mode=] is {{XRSessionMode/"inline"}} and |session|'s {{XRSession/renderState}}'s [=XRRenderState/output canvas=] is <code>null</code>, abort these steps.


### PR DESCRIPTION
Fixes #1010 

Second attempt at https://github.com/immersive-web/webxr/pull/1086

This PR only caches:

 - XRViewport obejcts when the viewport has not changed
 - XRFrame objects for animation frames

We determined that caching poses is probably too dangerous since they're "plain old data" types that folks may choose to hold on to. Leaving #1086 as a separate PR if people are interested in seeing how that would work.

cc @asajeffrey @MortimerGoro @cabanier


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1088.html" title="Last updated on Jun 26, 2020, 5:06 PM UTC (deb6236)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1088/9106241...Manishearth:deb6236.html" title="Last updated on Jun 26, 2020, 5:06 PM UTC (deb6236)">Diff</a>