### PR TITLE
void -> undefined in WebIDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -595,13 +595,13 @@ enum XRVisibilityState {
   [SameObject] readonly attribute XRInputSourceArray inputSources;
 
   // Methods
-  void updateRenderState(optional XRRenderStateInit state = {});
+  undefined updateRenderState(optional XRRenderStateInit state = {});
   [NewObject] Promise&lt;XRReferenceSpace&gt; requestReferenceSpace(XRReferenceSpaceType type);
 
   unsigned long requestAnimationFrame(XRFrameRequestCallback callback);
-  void cancelAnimationFrame(unsigned long handle);
+  undefined cancelAnimationFrame(unsigned long handle);
 
-  Promise&lt;void&gt; end();
+  Promise&lt;undefined&gt; end();
 
   // Events
   attribute EventHandler onend;
@@ -908,7 +908,7 @@ Animation Frames {#animation-frames}
 The primary way an {{XRSession}} provides information about the tracking state of the [=XRSession/XR device=] is via callbacks scheduled by calling {{requestAnimationFrame()}} on the {{XRSession}} instance.
 
 <pre class="idl">
-callback XRFrameRequestCallback = void (DOMHighResTimeStamp time, XRFrame frame);
+callback XRFrameRequestCallback = undefined (DOMHighResTimeStamp time, XRFrame frame);
 </pre>
 
 Each {{XRFrameRequestCallback}} object has a <dfn for="XRFrameRequestCallback">cancelled</dfn> boolean initially set to <code>false</code>.
@@ -2045,7 +2045,7 @@ partial dictionary WebGLContextAttributes {
 };
 
 partial interface mixin WebGLRenderingContextBase {
-    [NewObject] Promise&lt;void&gt; makeXRCompatible();
+    [NewObject] Promise&lt;undefined&gt; makeXRCompatible();
 };
 </pre>
 


### PR DESCRIPTION
Should be identical to the change #1116 intended to make, without the weird diff against an outdated spec version.

Changes any instances of `void` in WebIDL to `undefined` as outlined in [this recent change](https://github.com/heycam/webidl/issues/60).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/pull/1117.html" title="Last updated on Aug 18, 2020, 5:09 PM UTC (940926c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1117/e22bb8c...940926c.html" title="Last updated on Aug 18, 2020, 5:09 PM UTC (940926c)">Diff</a>