### PR TITLE
Switch over to use the newer (and more readable) bikeshed switch syntax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -288,10 +288,12 @@ Each time the [=list of immersive XR devices=] changes the user agent should <df
   1. If the [=list of immersive XR devices=]'s [=list/size=] is one, set the [=immersive XR device=] to the [=list of immersive XR devices=][0].
   1. Set the [=immersive XR device=] as follows:
     <dl class="switch">
-      <dt> If there are any active {{XRSession}}s and the [=list of immersive XR devices=] [=list/contains=] |oldDevice|
-      <dd> Set the [=immersive XR device=] to |oldDevice|
-      <dt> Otherwise
-      <dd> Set the [=immersive XR device=] to a device of the user agent's choosing
+      : If there are any active {{XRSession}}s and the [=list of immersive XR devices=] [=list/contains=] |oldDevice|:
+      :: Set the [=immersive XR device=] to |oldDevice|.
+
+      : Otherwise:
+      :: Set the [=immersive XR device=] to a device of the user agent's choosing.
+
     </dl>
   1. The user agent MAY update the [=/inline XR device=] to the [=immersive XR device=] if appropriate, or the [=/default inline XR device=] otherwise.
   1. If this is the first time devices have been enumerated or |oldDevice| equals the [=immersive XR device=], abort these steps.
@@ -373,14 +375,15 @@ When this method is invoked, the user agent MUST run the following steps:
   1. Let |global object| be the [=relevant Global object=] for the {{XRSystem}} on which this method was invoked.
   1. Check whether the session request is allowed as follows:
     <dl class="switch">
-      <dt>If |immersive| is <code>true</code></dt>
-      <dd>
+      : If |immersive| is <code>true</code>:
+      ::
         1. Check if an [=immersive session request is allowed=] for the |global object|, and if not [=reject=] |promise| with a "{{SecurityError}}" {{DOMException}} and return |promise|.
         1. If [=pending immersive session=] is <code>true</code> or [=active immersive session=] is not <code>null</code>, [=reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}} and return |promise|.
         1. Set [=pending immersive session=] to <code>true</code>.
-      </dd>
-      <dt>Otherwise</dt>
-      <dd>Check if an [=inline session request is allowed=] for the |global object|, and if not [=reject=] |promise| with a "{{SecurityError}}" {{DOMException}} and return |promise|.</dd>
+
+      : Otherwise:
+      :: Check if an [=inline session request is allowed=] for the |global object|, and if not [=reject=] |promise| with a "{{SecurityError}}" {{DOMException}} and return |promise|.
+
     </dl>
   1. Run the following steps [=in parallel=]:
     1. Let |requiredFeatures| be |options|' {{XRSessionInit/requiredFeatures}}.
@@ -402,10 +405,12 @@ When this method is invoked, the user agent MUST run the following steps:
         1. [=Initialize the session=] with |session|, |mode|, and |device|.
         1. Potentially set the [=active immersive session=] as follows:
             <dl class="switch">
-              <dt> If |immersive| is <code>true</code>
-              <dd> Set the [=active immersive session=] to |session|, and set [=pending immersive session=] to <code>false</code>.
-              <dt> Otherwise
-              <dd> Append |session| to the [=list of inline sessions=].
+              : If |immersive| is <code>true</code>:
+              :: Set the [=active immersive session=] to |session|, and set [=pending immersive session=] to <code>false</code>.
+
+              : Otherwise:
+              :: Append |session| to the [=list of inline sessions=].
+
             </dl>
         1. [=/Resolve=] |promise| with |session|.
         1. [=Queue a task=] to perform the following steps:
@@ -425,12 +430,15 @@ To <dfn>obtain the current device</dfn> for an {{XRSessionMode}} |mode|, |requir
 
   1. Choose |device| as follows:
       <dl class="switch">
-        <dt>If |mode| is an [=immersive session=] mode:</dt>
-        <dd> Set |device| to the result of [=ensure an immersive XR device is selected|ensuring an immersive XR device is selected=].</dd>
-        <dt>Else if |requiredFeatures| or |optionalFeatures| are not empty:</dt>
-        <dd>Set |device| to the [=/inline XR device=].</dd>
-        <dt>Otherwise</dt>
-        <dd>Set |device| to the [=/default inline XR device=].</dd>
+        : If |mode| is an [=immersive session=] mode:
+        :: Set |device| to the result of [=ensure an immersive XR device is selected|ensuring an immersive XR device is selected=].
+
+        : Else if |requiredFeatures| or |optionalFeatures| are not empty:
+        :: Set |device| to the [=/inline XR device=].
+
+        : Otherwise:
+        :: Set |device| to the [=/default inline XR device=].
+
       </dl>
   1. Return |device|.
 
@@ -719,12 +727,14 @@ When requested, the {{XRSession}} |session| MUST <dfn>apply the pending render s
     1. Let |baseLayer| be |activeState|'s {{XRRenderState/baseLayer}}.
     1. Set |activeState|'s [=XRRenderState/composition disabled=] and [=XRRenderState/output canvas=] as follows:
         <dl class="switch">
-          <dt> If |session|'s [=XRSession/mode=] is {{XRSessionMode/"inline"}} and |baseLayer| is an instance of an {{XRWebGLLayer}} with [=XRWebGLLayer/composition disabled=] set to <code>true</code>
-          <dd> Set |activeState|'s [=XRRenderState/composition disabled=] boolean to <code>true</code>.
-          <dd> Set |activeState|'s [=XRRenderState/output canvas=] to |baseLayer|'s [=XRWebGLLayer/context=]'s {{WebGLRenderingContext|canvas}}.
-          <dt> Otherwise
-          <dd> Set |activeState|'s [=XRRenderState/composition disabled=] boolean to <code>false</code>.
-          <dd> Set |activeState|'s [=XRRenderState/output canvas=] to <code>null</code>.
+          : If |session|'s [=XRSession/mode=] is {{XRSessionMode/"inline"}} and |baseLayer| is an instance of an {{XRWebGLLayer}} with [=XRWebGLLayer/composition disabled=] set to <code>true</code>:
+          :: Set |activeState|'s [=XRRenderState/composition disabled=] boolean to <code>true</code>.
+          :: Set |activeState|'s [=XRRenderState/output canvas=] to |baseLayer|'s [=XRWebGLLayer/context=]'s {{WebGLRenderingContext|canvas}}.
+
+          : Otherwise:
+          :: Set |activeState|'s [=XRRenderState/composition disabled=] boolean to <code>false</code>.
+          :: Set |activeState|'s [=XRRenderState/output canvas=] to <code>null</code>.
+
         </dl>
 
 </div>
@@ -878,15 +888,17 @@ Note: At this point the {{XRRenderState}} will only have an [=XRRenderState/outp
 
 When an {{XRRenderState}} object is created for an {{XRSession}} |session|, the user agent MUST <dfn>initialize the render state</dfn> by running the following steps:
 
-  1. Let |state| be a [=new=] {{XRRenderState}} object in the [=relevant realm=] of |session|         .
+  1. Let |state| be a [=new=] {{XRRenderState}} object in the [=relevant realm=] of |session|.
   1. Initialize |state|'s {{XRRenderState/depthNear}} to <code>0.1</code>.
   1. Initialize |state|'s {{XRRenderState/depthFar}} to <code>1000.0</code>.
   1. Initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} as follows:
     <dl class="switch">
-      <dt> If |session| is an [=inline session=]
-      <dd> Initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} to <code>PI * 0.5</code>.
-      <dt> Else
-      <dd> Initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} to <code>null</code>.
+      : If |session| is an [=inline session=]:
+      :: Initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} to <code>PI * 0.5</code>.
+
+      : Otherwise:
+      :: Initialize |state|'s {{XRRenderState/inlineVerticalFieldOfView}} to <code>null</code>.
+
     </dl>
   1. Initialize |state|'s {{XRRenderState/baseLayer}} to <code>null</code>.
 
@@ -1148,23 +1160,24 @@ To <dfn>populate the pose</dfn> of an {{XRSpace}} |space| in an {{XRSpace}} |bas
   1. Let |transform| be |pose|'s {{XRPose/transform}}.
   1. Query the [=/XR device=]'s tracking system for |space|'s pose relative to |baseSpace| at the |frame|'s [=XRFrame/time=], then perform the following steps:
     <dl class="switch">
-      <dt> If |limit| is <code>false</code> and the tracking system provides a [=6DoF=] pose whose position is actively tracked or statically known for |space|'s pose relative to |baseSpace|:
-        <dd> Set |transform|'s {{XRRigidTransform/orientation}} to the orientation of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
-        <dd> Set |transform|'s {{XRRigidTransform/position}} to the position of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
-        <dd> Set |pose|'s {{XRPose/emulatedPosition}} to <code>false</code>.
+      : If |limit| is <code>false</code> and the tracking system provides a [=6DoF=] pose whose position is actively tracked or statically known for |space|'s pose relative to |baseSpace|:
+      :: Set |transform|'s {{XRRigidTransform/orientation}} to the orientation of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
+      :: Set |transform|'s {{XRRigidTransform/position}} to the position of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
+      :: Set |pose|'s {{XRPose/emulatedPosition}} to <code>false</code>.
 
-      <dt> Else if |limit| is <code>false</code> and the tracking system provides a [=3DoF=] pose or a [=6DoF=] pose whose position is neither actively tracked nor statically known for |space|'s pose relative to |baseSpace|:
-        <dd> Set |transform|'s {{XRRigidTransform/orientation}} to the orientation of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
-        <dd> Set |transform|'s {{XRRigidTransform/position}} to the tracking system's best estimate of the position of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=]. This MAY include a computed offset such as a neck or arm model. If a position estimate is not available, the last known position MUST be used.
-        <dd> Set |pose|'s {{XRPose/emulatedPosition}} to <code>true</code>.
+      : Else if |limit| is <code>false</code> and the tracking system provides a [=3DoF=] pose or a [=6DoF=] pose whose position is neither actively tracked nor statically known for |space|'s pose relative to |baseSpace|:
+      :: Set |transform|'s {{XRRigidTransform/orientation}} to the orientation of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
+      :: Set |transform|'s {{XRRigidTransform/position}} to the tracking system's best estimate of the position of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=]. This MAY include a computed offset such as a neck or arm model. If a position estimate is not available, the last known position MUST be used.
+      :: Set |pose|'s {{XRPose/emulatedPosition}} to <code>true</code>.
 
-      <dt> Else if |space|'s pose relative to |baseSpace| has been determined in the past and |force emulation| is <code>true</code>:
-        <dd> Set |transform|'s {{XRRigidTransform/position}} to the last known position of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
-        <dd> Set |transform|'s {{XRRigidTransform/orientation}} to the last known orientation of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
-        <dd> Set |pose|'s {{XRPose/emulatedPosition}} boolean to <code>true</code>.
+      : Else if |space|'s pose relative to |baseSpace| has been determined in the past and |force emulation| is <code>true</code>:
+      :: Set |transform|'s {{XRRigidTransform/position}} to the last known position of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
+      :: Set |transform|'s {{XRRigidTransform/orientation}} to the last known orientation of |space|'s [=effective origin=] in |baseSpace|'s [=coordinate system=].
+      :: Set |pose|'s {{XRPose/emulatedPosition}} boolean to <code>true</code>.
 
-      <dt> Otherwise:
-        <dd> Set |pose| to <code>null</code>.
+      : Otherwise:
+      :: Set |pose| to <code>null</code>.
+
     </dl>
 
 Note: The {{XRPose}}'s {{XRPose/emulatedPosition}} boolean does not indicate whether |baseSpace|'s position is emulated or not, only whether evaluating |space|'s position relative to |baseSpace| relies on emulation. For example, a controller with [=3DoF=] tracking would report poses with an {{XRPose/emulatedPosition}} of <code>true</code> when its {{targetRaySpace}} or {{gripSpace}} are queried against an {{XRReferenceSpace}}, but would report an {{XRPose/emulatedPosition}} of <code>false</code> if the pose of the {{targetRaySpace}} was queried in {{gripSpace}}, because the relationship between those two spaces should be known exactly.
@@ -1221,10 +1234,12 @@ When an {{XRReferenceSpace}} is requested with {{XRReferenceSpaceType}} |type| f
 
   1. Initialize |referenceSpace| as follows:
       <dl class="switch">
-        <dt> If |type| is {{bounded-floor}}
-        <dd> Let |referenceSpace| be a [=new=] {{XRBoundedReferenceSpace}} in the [=relevant realm=] of |session|.
-        <dt> Otherwise
-        <dd> Let |referenceSpace| be a [=new=] {{XRReferenceSpace}} in the [=relevant realm=] of |session|.
+        : If |type| is {{bounded-floor}}:
+        :: Let |referenceSpace| be a [=new=] {{XRBoundedReferenceSpace}} in the [=relevant realm=] of |session|.
+
+        : Otherwise:
+        :: Let |referenceSpace| be a [=new=] {{XRReferenceSpace}} in the [=relevant realm=] of |session|.
+
       </dl>
   1. Initialize |referenceSpace|'s [=XRReferenceSpace/type=] to |type|.
   1. Initialize |referenceSpace|'s [=XRSpace/session=] to |session|.
@@ -1251,10 +1266,12 @@ The <dfn method for="XRReferenceSpace">getOffsetReferenceSpace(|originOffset|)</
   1. Let |base| be the {{XRReferenceSpace}} the method was called on.
   1. Initialize |offsetSpace| as follows:
     <dl class="switch">
-      <dt> If |base| is an instance of {{XRBoundedReferenceSpace}}
-      <dd> Let |offsetSpace| be a [=new=] {{XRBoundedReferenceSpace}} in the [=relevant realm=] of |base|, and set |offsetSpace|'s {{boundsGeometry}} to |base|'s {{boundsGeometry}}, with each point multiplied by the {{XRRigidTransform/inverse}} of |originOffset|.
-      <dt> Else
-      <dd> Let |offsetSpace| be a [=new=] {{XRReferenceSpace}} in the [=relevant realm=] of |base|.
+      : If |base| is an instance of {{XRBoundedReferenceSpace}}:
+      :: Let |offsetSpace| be a [=new=] {{XRBoundedReferenceSpace}} in the [=relevant realm=] of |base|, and set |offsetSpace|'s {{boundsGeometry}} to |base|'s {{boundsGeometry}}, with each point multiplied by the {{XRRigidTransform/inverse}} of |originOffset|.
+
+      : Otherwise:
+      :: Let |offsetSpace| be a [=new=] {{XRReferenceSpace}} in the [=relevant realm=] of |base|.
+
     </dl>
   1. Set |offsetSpace|'s [=XRReferenceSpace/type=] to |base|'s [=XRReferenceSpace/type=].
   1. Set |offsetSpace|'s [=origin offset=] to the result of [=multiply transforms|multiplying=] |base|'s [=origin offset=] by |originOffset| in the [=relevant realm=] of |base|.
@@ -1887,21 +1904,25 @@ The <dfn constructor for="XRWebGLLayer">XRWebGLLayer(|session|, |context|, |laye
   1. Initialize |layer|'s [=XRWebGLLayer/session=] to |session|.
   1. Initialize |layer|'s {{XRWebGLLayer/ignoreDepthValues}} as follows:
     <dl class="switch">
-      <dt> If |layerInit|'s {{XRWebGLLayerInit/ignoreDepthValues}} value is <code>false</code> and the [=XR Compositor=] will make use of depth values
-      <dd> Initialize |layer|'s {{XRWebGLLayer/ignoreDepthValues}} to <code>false</code>
-      <dt> Otherwise
-      <dd> Initialize |layer|'s {{XRWebGLLayer/ignoreDepthValues}} to <code>true</code>
+      : If |layerInit|'s {{XRWebGLLayerInit/ignoreDepthValues}} value is <code>false</code> and the [=XR Compositor=] will make use of depth values:
+      :: Initialize |layer|'s {{XRWebGLLayer/ignoreDepthValues}} to <code>false</code>.
+
+      : Otherwise:
+      :: Initialize |layer|'s {{XRWebGLLayer/ignoreDepthValues}} to <code>true</code>.
+
     </dl>
   1. Initialize |layer|'s [=XRWebGLLayer/composition disabled=] boolean as follows:
     <dl class="switch">
-      <dt> If |session| is an [=inline session=]
-      <dd> Initialize |layer|'s [=XRWebGLLayer/composition disabled=] to <code>true</code>
-      <dt> Otherwise
-      <dd> Initialize |layer|'s [=XRWebGLLayer/composition disabled=] boolean to <code>false</code>
+      : If |session| is an [=inline session=]:
+      :: Initialize |layer|'s [=XRWebGLLayer/composition disabled=] to <code>true</code>.
+
+      : Otherwise:
+      :: Initialize |layer|'s [=XRWebGLLayer/composition disabled=] boolean to <code>false</code>.
+
     </dl>
   1. <dl class="switch">
-      <dt> If |layer|'s [=XRWebGLLayer/composition disabled=] boolean is <code>false</code>:
-      <dd>
+      : If |layer|'s [=XRWebGLLayer/composition disabled=] boolean is <code>false</code>:
+      ::
         1. Initialize |layer|'s {{XRWebGLLayer/antialias}} to |layerInit|'s {{XRWebGLLayerInit/antialias}} value.
         1. Let |scaleFactor| be |layerInit|'s {{XRWebGLLayerInit/framebufferScaleFactor}}.
         1. The user-agent MAY choose to clamp or round |scaleFactor| as it sees fit here, for example if it wishes to fit the buffer dimensions into a power of two for performance reasons.
@@ -1909,10 +1930,12 @@ The <dfn constructor for="XRWebGLLayer">XRWebGLLayer(|session|, |context|, |laye
         1. Initialize |layer|'s {{XRWebGLLayer/framebuffer}} to a [=new=] {{WebGLFramebuffer}} in the [=relevant realm=] of |context|, which is an [=opaque framebuffer=] with the dimensions |framebufferSize| created with |context|, [=opaque framebuffer/session=] initialized to |session|, and |layerInit|'s {{XRWebGLLayerInit/depth}}, {{XRWebGLLayerInit/stencil}}, and {{XRWebGLLayerInit/alpha}} values.
         1. Allocate and initialize resources compatible with |session|'s [=XRSession/XR device=], including GPU accessible memory buffers, as required to support the compositing of |layer|.
         1. If |layer|’s resources were unable to be created for any reason, throw an {{OperationError}} and abort these steps.
-      <dt> Otherwise
-      <dd>
+
+      : Otherwise:
+      ::
         1. Initialize |layer|'s {{XRWebGLLayer/antialias}} to |layer|'s {{XRWebGLLayer/context}}'s [=actual context parameters=] {{WebGLContextAttributes|antialias}} value.
         1. Initialize |layer|'s {{XRWebGLLayer/framebuffer}} to <code>null</code>.
+
     </dl>
   1. Return |layer|.
 
@@ -2089,32 +2112,37 @@ When this method is invoked, the user agent MUST run the following steps:
     1. Let |device| be the result of [=ensure an immersive XR device is selected|ensuring an immersive XR device is selected=].
     1. Set |context|'s [=XR compatible=] boolean as follows:
         <dl class="switch">
-          <dt> If |context|'s [=WebGL context lost flag=] is set
-          <dd> [=Queue a task=] to set |context|'s [=XR compatible=] boolean to <code>false</code> and [=reject=] |promise| with an {{InvalidStateError}}.
-          <dt> If |device| is <code>null</code>
-          <dd> [=Queue a task=] to set |context|'s [=XR compatible=] boolean to <code>false</code> and [=reject=] |promise| with an {{InvalidStateError}}.
-          <dt> If |context|'s [=XR compatible=] boolean is <code>true</code>
-          <dd> [=Queue a task=] to [=/resolve=] |promise|.
-          <dt> If |context| was created on a [=compatible graphics adapter=] for |device|.
-          <dd> [=Queue a task=] to set |context|'s [=XR compatible=] boolean to <code>true</code> and [=/resolve=] |promise|.
-          <dt> Otherwise
-          <dd> [=Queue a task=] on the [=/WebGL task source=] to perform the following steps:
-                  1. Force |context| to be lost.
-                  1. [=Handle the context loss=] as described by the WebGL specification:
-                      1. Let |canvas| be the |context|'s [=WebGLRenderingContext/canvas=].
-                      1. If |context|'s [=WebGLRenderingContext/webgl context lost flag=] is set, abort these steps.
-                      1. Set |context|'s [=WebGLRenderingContext/webgl context lost flag=].
-                      1. Set the [=WebGLObject/invalidated=] flag of each {{WebGLObject}} instance created by |context|.
-                      1. Disable all extensions except "WEBGL_lose_context".
-                      1. [=Queue a task=] on the [=/WebGL task source=] to perform the following steps:
-                          1. [=Fire a WebGL context event=] |e| named "webglcontextlost" at |canvas|, with {{WebGLContextEvent/statusMessage}} set to "".
-                          1. If |e|'s [=canceled flag=] is not set, [=reject=] |promise| with an {{AbortError}} and abort these steps.
-                          1. Run the following steps [=in parallel=].
-                              1. Await a restorable drawing buffer on a [=compatible graphics adapter=] for |device|.
-                              1. [=Queue a task=] on the [=/WebGL task source=] to perform the following steps:
-                                  1. [=Restore the context=] on a [=compatible graphics adapter=] for |device|.
-                                  1. Set |context|'s [=XR compatible=] boolean to <code>true</code>.
-                                  1. [=/Resolve=] |promise|.
+          : If |context|'s [=WebGL context lost flag=] is set:
+          :: [=Queue a task=] to set |context|'s [=XR compatible=] boolean to <code>false</code> and [=reject=] |promise| with an {{InvalidStateError}}.
+
+          : If |device| is <code>null</code>:
+          :: [=Queue a task=] to set |context|'s [=XR compatible=] boolean to <code>false</code> and [=reject=] |promise| with an {{InvalidStateError}}.
+
+          : If |context|'s [=XR compatible=] boolean is <code>true</code>:
+          :: [=Queue a task=] to [=/resolve=] |promise|.
+
+          : If |context| was created on a [=compatible graphics adapter=] for |device|:
+          :: [=Queue a task=] to set |context|'s [=XR compatible=] boolean to <code>true</code> and [=/resolve=] |promise|.
+
+          : Otherwise:
+          :: [=Queue a task=] on the [=/WebGL task source=] to perform the following steps:
+            1. Force |context| to be lost.
+            1. [=Handle the context loss=] as described by the WebGL specification:
+                1. Let |canvas| be the |context|'s [=WebGLRenderingContext/canvas=].
+                1. If |context|'s [=WebGLRenderingContext/webgl context lost flag=] is set, abort these steps.
+                1. Set |context|'s [=WebGLRenderingContext/webgl context lost flag=].
+                1. Set the [=WebGLObject/invalidated=] flag of each {{WebGLObject}} instance created by |context|.
+                1. Disable all extensions except "WEBGL_lose_context".
+                1. [=Queue a task=] on the [=/WebGL task source=] to perform the following steps:
+                    1. [=Fire a WebGL context event=] |e| named "webglcontextlost" at |canvas|, with {{WebGLContextEvent/statusMessage}} set to "".
+                    1. If |e|'s [=canceled flag=] is not set, [=reject=] |promise| with an {{AbortError}} and abort these steps.
+                    1. Run the following steps [=in parallel=].
+                        1. Await a restorable drawing buffer on a [=compatible graphics adapter=] for |device|.
+                        1. [=Queue a task=] on the [=/WebGL task source=] to perform the following steps:
+                            1. [=Restore the context=] on a [=compatible graphics adapter=] for |device|.
+                            1. Set |context|'s [=XR compatible=] boolean to <code>true</code>.
+                            1. [=/Resolve=] |promise|.
+
         </dl>
   1. Return |promise|.
 
@@ -2396,14 +2424,18 @@ To determine if <dfn>poses may be reported</dfn> to an {{XRSession}} |session|, 
   1. If |session|'s {{XRSession/visibilityState}} in not {{XRVisibilityState/"visible"}}, return <code>false</code>.
   1. Determine if the pose data can be returned as follows:
     <dl class="switch">
-      <dt> If the pose data is known by the user agent to not expose fingerprintable sensor data
-      <dd> Return <code>true</code>.
-      <dt> If [=data adjustments=] will be applied to the underlying sensor data to prevent fingerprinting or profiling
-      <dd> Return <code>true</code>.
-      <dt> If [=user intent=] is well understood, either via [=explicit consent=] or [=implicit consent=]
-      <dd> Return <code>true</code>.
-      <dt> Otherwise
-      <dd> Return <code>false</code>.
+      : If the pose data is known by the user agent to not expose fingerprintable sensor data
+      :: Return <code>true</code>.
+
+      : If [=data adjustments=] will be applied to the underlying sensor data to prevent fingerprinting or profiling
+      :: Return <code>true</code>.
+
+      : If [=user intent=] is well understood, either via [=explicit consent=] or [=implicit consent=]
+      :: Return <code>true</code>.
+
+      : Otherwise
+      :: Return <code>false</code>.
+
     </dl>
 
 


### PR DESCRIPTION
Purely an aesthetic choice. I find this far more pleasant to read in bikeshed form, and it doesn't change the rendering (aside from a few inexplicable pixel shifts.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/pull/1125.html" title="Last updated on Sep 14, 2020, 10:50 PM UTC (527e1ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1125/e27913c...527e1ef.html" title="Last updated on Sep 14, 2020, 10:50 PM UTC (527e1ef)">Diff</a>