### PR TITLE
Ensure that pending render state is always applied.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -961,6 +961,14 @@ NOTE: The <a href="https://immersive-web.github.io/layers">WebXR layers module</
 
 </div>
 
+<div class="algorithm" data-algorithm="should-be-rendered">
+To determine if a frame <dfn>should be rendered</dfn> for {{XRSession}} |session|, the user agent MUST run the following steps:
+  1. If [=check the layers state=] with |session|'s {{XRSession/renderState}} is <code>false</code>, return <code>false</code>.
+  1. If |session|'s  [=XRSession/mode=] is {{XRSessionMode/"inline"}} and |session|'s {{XRSession/renderState}}'s [=XRRenderState/output canvas=] is <code>null</code>, return <code>false</code>.
+  1. return <code>true</code>.
+
+</div>
+
 <div class="algorithm" data-algorithm="run-animation-frames">
 
 When an {{XRSession}} |session| receives updated [=viewer=] state for timestamp |frameTime| from the [=XRSession/XR device=], it runs an <dfn>XR animation frame</dfn>, which MUST run the following steps regardless of if the [=list of animation frame callbacks=] is empty or not:
@@ -970,18 +978,17 @@ When an {{XRSession}} |session| receives updated [=viewer=] state for timestamp 
     1. Let |frame| be |session|'s [=XRSession/animation frame=].
     1. Set |frame|'s [=XRFrame/time=] to |frameTime|.
     1. If the [=view/active=] flag of any [=view=] in the [=XRSession/list of views=] has changed since the last [=XR animation frame=], [=update the viewports=].
-    1. If [=check the layers state=] with |session|'s {{XRSession/renderState}} is <code>false</code>, abort these steps.
-    1. If |session|'s  [=XRSession/mode=] is {{XRSessionMode/"inline"}} and |session|'s {{XRSession/renderState}}'s [=XRRenderState/output canvas=] is <code>null</code>, abort these steps.
-    1. Set  |session|'s [=list of currently running animation frame callbacks=] to be |session|'s [=list of animation frame callbacks=].
-    1. Set |session|'s [=list of animation frame callbacks=] to the empty list.
-    1. Set |frame|'s [=XRFrame/active=] boolean to <code>true</code>.
-    1. [=XRFrame/Apply frame updates=] for |frame|.
-    1. For each |entry| in |session|'s [=list of currently running animation frame callbacks=], in order:
-      1. If the |entry|'s [=cancelled=] boolean is <code>true</code>, continue to the next entry.
-      1. [=Invoke the Web IDL callback function=] for |entry|, passing |now| and |frame| as the  arguments
-      1. If an exception is thrown, [=report the exception=].
-    1. Set |session|'s [=list of currently running animation frame callbacks=] to the empty [=/list=].
-    1. Set |frame|'s [=XRFrame/active=] boolean to <code>false</code>.
+    1. If the frame [=should be rendered=] for |session|:
+        1. Set |session|'s [=list of currently running animation frame callbacks=] to be |session|'s [=list of animation frame callbacks=].
+        1. Set |session|'s [=list of animation frame callbacks=] to the empty list.
+        1. Set |frame|'s [=XRFrame/active=] boolean to <code>true</code>.
+        1. [=XRFrame/Apply frame updates=] for |frame|.
+        1. For each |entry| in |session|'s [=list of currently running animation frame callbacks=], in order:
+          1. If the |entry|'s [=cancelled=] boolean is <code>true</code>, continue to the next entry.
+          1. [=Invoke the Web IDL callback function=] for |entry|, passing |now| and |frame| as the  arguments
+          1. If an exception is thrown, [=report the exception=].
+        1. Set |session|'s [=list of currently running animation frame callbacks=] to the empty [=/list=].
+        1. Set |frame|'s [=XRFrame/active=] boolean to <code>false</code>.
     1. If |session|'s [=pending render state=] is not <code>null</code>, [=apply the pending render state=].
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -964,7 +964,7 @@ NOTE: The <a href="https://immersive-web.github.io/layers">WebXR layers module</
 <div class="algorithm" data-algorithm="should-be-rendered">
 To determine if a frame <dfn>should be rendered</dfn> for {{XRSession}} |session|, the user agent MUST run the following steps:
   1. If [=check the layers state=] with |session|'s {{XRSession/renderState}} is <code>false</code>, return <code>false</code>.
-  1. If |session|'s  [=XRSession/mode=] is {{XRSessionMode/"inline"}} and |session|'s {{XRSession/renderState}}'s [=XRRenderState/output canvas=] is <code>null</code>, return <code>false</code>.
+  1. If |session|'s [=XRSession/mode=] is {{XRSessionMode/"inline"}} and |session|'s {{XRSession/renderState}}'s [=XRRenderState/output canvas=] is <code>null</code>, return <code>false</code>.
   1. return <code>true</code>.
 
 </div>


### PR DESCRIPTION
Fixes #1127

This change allows the `apply the pending render state` algorithm to run even when the current layer state is invalid.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/pull/1128.html" title="Last updated on Sep 17, 2020, 5:49 PM UTC (afe353b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1128/bc96697...afe353b.html" title="Last updated on Sep 17, 2020, 5:49 PM UTC (afe353b)">Diff</a>