### PR TITLE
Make sessionsupported pref autogranting non-normative

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -620,9 +620,9 @@ dictionary XRSessionSupportedPermissionDescriptor: PermissionDescriptor {
 
 <section class="non-normative">
 
-In many situations, {{XRSystem/isSessionSupported()}} is not actually a fingerprinting vector. For such systems it is useful to automatically grant the {{PermissionName/"xr-session-supported"}} preference to provide for a better user experience and avoid permissions fatigue.
+There is often tension between privacy and personalization on the Web. This section provides guidance on where that tradeoff can be circumscribed, and when the user agent can describe the browser's WebXR capabilities to a site via {{XRSystem/isSessionSupported()}} without any privacy reduction.
 
-{{PermissionName/"xr-session-supported"}} may be granted automatically for some systems based on the criteria below.
+{{PermissionName/"xr-session-supported"}} may be granted automatically for some systems based on the criteria below. This can provide a better user experience and mitigate permissions fatigue.
 
 A set of user agents is <dfn>indistinguishable by user-agent string</dfn> if they all report the same {{NavigatorID/userAgent}} and {{NavigatorID/appVersion}}. Such classes are typically identified by the browser version and platform/device being run on, but cannot be distinguished by the status of any connected external device. We can use the concept of user agents that are [=indistinguishable by user-agent string=] to properly assess fingerprinting risk.
 

--- a/index.bs
+++ b/index.bs
@@ -616,15 +616,21 @@ dictionary XRSessionSupportedPermissionDescriptor: PermissionDescriptor {
 
 </dd></dl>
 
+### Automatic granting of {{PermissionName/"xr-session-supported"}} ### {#automatic-granting-xr-session-supported}
+
+<section class="non-normative">
+
+In many situations, {{XRSystem/isSessionSupported()}} is not actually a fingerprinting vector. For such systems it is useful to automatically grant the {{PermissionName/"xr-session-supported"}} preference to provide for a better user experience and avoid permissions fatigue.
+
 {{PermissionName/"xr-session-supported"}} may be granted automatically for some systems based on the criteria below.
 
 A set of user agents is <dfn>indistinguishable by user-agent string</dfn> if they all report the same {{NavigatorID/userAgent}} and {{NavigatorID/appVersion}}. Such classes are typically identified by the browser version and platform/device being run on, but cannot be distinguished by the status of any connected external device. We can use the concept of user agents that are [=indistinguishable by user-agent string=] to properly assess fingerprinting risk.
 
-Some user agents [=indistinguishable by user-agent string=] will <dfn>never support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents running on a model of phone that is known to not meet requirements for mobile AR support.</span> In these cases there is little fingerprinting risk in {{XRSystem/isSessionSupported()}} always reporting the {{XRSessionMode}} is not supported because every such device will consistently report the same value and it's assumed that device type and model can be inferred in other ways, such as through {{NavigatorID/userAgent}}. Thus, on such systems, the user-agent SHOULD automatically deny {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
+Some user agents [=indistinguishable by user-agent string=] will <dfn>never support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents running on a model of phone that is known to not meet requirements for mobile AR support.</span> In these cases there is little fingerprinting risk in {{XRSystem/isSessionSupported()}} always reporting the {{XRSessionMode}} is not supported because every such device will consistently report the same value and it's assumed that device type and model can be inferred in other ways, such as through {{NavigatorID/userAgent}}. Thus, on such systems, the user-agent should automatically deny {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
 
-Other user agents will [=indistinguishable by user-agent string=] <dfn>usually support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents known to support WebXR that run exclusively within VR headsets are likely to support {{XRSessionMode/"immersive-vr"}} sessions unless specifically blocked by the user.</span> In these cases reporting that the {{XRSessionMode}} is not supported, while accurate, would offer more uniquely identifying information about the user. As such reporting that the {{XRSessionMode}} is always available and allowing {{XRSystem/requestSession()}} to fail is more privacy-preserving while likely not being a source of confusion for the user. On such systems, the user-agent SHOULD automatically grant {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
+Other user agents will [=indistinguishable by user-agent string=] <dfn>usually support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents known to support WebXR that run exclusively within VR headsets are likely to support {{XRSessionMode/"immersive-vr"}} sessions unless specifically blocked by the user.</span> In these cases reporting that the {{XRSessionMode}} is not supported, while accurate, would offer more uniquely identifying information about the user. As such reporting that the {{XRSessionMode}} is always available and allowing {{XRSystem/requestSession()}} to fail is more privacy-preserving while likely not being a source of confusion for the user. On such systems, the user-agent should automatically grant {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
 
-User agents [=indistinguishable by user-agent string=] for which availability of XR capabilities is highly variable, such as desktop systems which support XR peripherals, present the highest fingerprinting risk. User agents on such devices SHOULD NOT automatically grant {{PermissionName/"xr-session-supported"}} in a way that allows the {{isSessionSupported()}} API to provide additional fingerprinting bits. 
+User agents [=indistinguishable by user-agent string=] for which availability of XR capabilities is highly variable, such as desktop systems which support XR peripherals, present the highest fingerprinting risk. User agents on such devices should not automatically grant {{PermissionName/"xr-session-supported"}} in a way that allows the {{isSessionSupported()}} API to provide additional fingerprinting bits. 
 
 
 <div class=note>
@@ -636,8 +642,9 @@ Note: Some acceptable approaches to handle such cases are as follows:
 
 </div>
 
-Whatever the technique chosen, it MUST NOT reveal additional knowledge about connected XR hardware without [=explicit consent=].
+Whatever the technique chosen, it should not reveal additional knowledge about connected XR hardware without [=explicit consent=].
 
+</section>
 
 Session {#session}
 =======

--- a/index.bs
+++ b/index.bs
@@ -597,7 +597,7 @@ Fingerprinting considerations of {{XRSystem/isSessionSupported()}} {#issessionsu
 ----------------------------------
 Because {{XRSystem/isSessionSupported()}} can be called without user activation it may be used as a fingerprinting vector despite the limited amount of information it reports.
 
-<dfn enum-value for="PermissionName">"xr-session-supported"</dfn> [=powerful feature=] gates access to the {{XRSystem/isSessionSupported()}} API in cases where there are fingerprinting concerns.
+<dfn enum-value for="PermissionName">"xr-session-supported"</dfn> [=powerful feature=] gates access to the {{XRSystem/isSessionSupported()}} API.
 
 The {{PermissionName/"xr-session-supported"}}’s permission-related algorithms and types are defined as follows:
 

--- a/index.bs
+++ b/index.bs
@@ -595,7 +595,7 @@ Note: For example, several VR devices support either configuring a safe boundary
 
 Fingerprinting considerations of {{XRSystem/isSessionSupported()}} {#issessionsupported-fingerprinting}
 ----------------------------------
-Because {{XRSystem/isSessionSupported()}} can be called without user activation it may be used as a fingerprinting vector despite the limited amount of information it reports.
+Because {{XRSystem/isSessionSupported()}} can be called without user activation it may be used as a fingerprinting vector.
 
 <dfn enum-value for="PermissionName">"xr-session-supported"</dfn> [=powerful feature=] gates access to the {{XRSystem/isSessionSupported()}} API.
 

--- a/index.bs
+++ b/index.bs
@@ -375,52 +375,6 @@ if (supported) {
 </pre>
 </div>
 
-### Fingerprinting considerations ### {#issessionsupported-fingerprinting}
-
-Because {{XRSystem/isSessionSupported()}} can be called without user activation it may be used as a fingerprinting vector despite the limited amount of information it reports.
-
-<dfn enum-value for="PermissionName">"xr-session-supported"</dfn> [=powerful feature=] gates access to the {{XRSystem/isSessionSupported()}} API in cases where there are fingerprinting concerns.
-
-The {{PermissionName/"xr-session-supported"}}’s permission-related algorithms and types are defined as follows:
-
-
-<dl>
-<dt>[=permission descriptor type=]</dt>
-<dd>
-
-<pre class="idl">
-dictionary XRSessionSupportedPermissionDescriptor: PermissionDescriptor {
-  XRSessionMode mode;
-};
-</pre>
-
-{{PermissionDescriptor/name}} for {{XRPermissionDescriptor}} is {{PermissionName/"xr-session-supported"}}.
-
-</dd></dl>
-
-{{PermissionName/"xr-session-supported"}} may be granted automatically for some systems based on the criteria below.
-
-A set of user agents is <dfn>indistinguishable by user-agent string</dfn> if they all report the same {{NavigatorID/userAgent}} and {{NavigatorID/appVersion}}. Such classes are typically identified by the browser version and platform/device being run on, but cannot be distinguished by the status of any connected external device. We can use the concept of user agents that are [=indistinguishable by user-agent string=] to properly assess fingerprinting risk.
-
-Some user agents [=indistinguishable by user-agent string=] will <dfn>never support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents running on a model of phone that is known to not meet requirements for mobile AR support.</span> In these cases there is little fingerprinting risk in {{XRSystem/isSessionSupported()}} always reporting the {{XRSessionMode}} is not supported because every such device will consistently report the same value and it's assumed that device type and model can be inferred in other ways, such as through {{NavigatorID/userAgent}}. Thus, on such systems, the user-agent SHOULD automatically deny {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
-
-Other user agents will [=indistinguishable by user-agent string=] <dfn>usually support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents known to support WebXR that run exclusively within VR headsets are likely to support {{XRSessionMode/"immersive-vr"}} sessions unless specifically blocked by the user.</span> In these cases reporting that the {{XRSessionMode}} is not supported, while accurate, would offer more uniquely identifying information about the user. As such reporting that the {{XRSessionMode}} is always available and allowing {{XRSystem/requestSession()}} to fail is more privacy-preserving while likely not being a source of confusion for the user. On such systems, the user-agent SHOULD automatically grant {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
-
-User agents [=indistinguishable by user-agent string=] for which availability of XR capabilities is highly variable, such as desktop systems which support XR peripherals, present the highest fingerprinting risk. User agents on such devices SHOULD NOT automatically grant {{PermissionName/"xr-session-supported"}} in a way that allows the {{isSessionSupported()}} API to provide additional fingerprinting bits. 
-
-
-<div class=note>
-Note: Some acceptable approaches to handle such cases are as follows:
-
- - Always judging [=explicit consent=] for {{PermissionName/"xr-session-supported"}} (with a potentially cached permissions prompt or similar) when {{XRSystem/isSessionSupported()}} is called.
- - Automatically granting {{PermissionName/"xr-session-supported"}} but having {{XRSystem/isSessionSupported()}} always report `true` even on platforms which do not consistently have XR capabilities available, regardless of whether or not the appropriate hardware or software is present. This comes at the cost of user ergonomics, as it will cause pages to advertise XR content to users that cannot view it.
- - Have {{XRSystem/isSessionSupported()}} request [=explicit consent=] for {{PermissionName/"xr-session-supported"}} when the appropriate hardware is present, and when such hardware is _not_ present, return `false` after an appropriately random length of time. In such an implementation content must not be able to distinguish between cases where the user agent was not connected to XR hardware and cases where the user agent was connected to XR hardware but the user declined to provide [=explicit consent=].
-
-</div>
-
-Whatever the technique chosen, it MUST NOT reveal additional knowledge about connected XR hardware without [=explicit consent=].
-
-
 The {{XRSystem}} object has a <dfn>pending immersive session</dfn> boolean, which MUST be initially `false`, an <dfn>active immersive session</dfn>, which MUST be initially `null`, and a <dfn>list of inline sessions</dfn>, which MUST be initially empty.
 
 <div class="algorithm" data-algorithm="request-session">
@@ -637,6 +591,53 @@ Note: {{XRReferenceSpaceType/"local"}} is always included in the [=requested fea
 [=Requested features=] can only be enabled for a session if the [=XRSession/XR device=] is <dfn>capable of supporting</dfn> the feature, which means that the feature is known to be supported by the [=XRSession/XR device=] in some configurations, even if the current configuration has not yet been verified as supporting the feature. The user agent MAY apply more rigorous constraints if desired in order to yield a more consistent user experience.
 
 Note: For example, several VR devices support either configuring a safe boundary for the user to move around within or skipping boundary configuration and operating in a mode where the user is expected to stand in place. Such a device can be considered to be [=capable of supporting=] {{"bounded-floor"}} {{XRReferenceSpace}}s even if they are currently not configured with safety boundaries, because it's expected that the user could configure the device appropriately if the experience required it. This is to allow user agents to avoid fully initializing the [=XRSession/XR device=] or waiting for the user's environment to be recognized prior to [=resolve the requested features|resolving the requested features=] if desired. If, however, the user agent knows that the boundary state at the time the session is requested without additional initialization it may choose to reject the {{"bounded-floor"}} feature if the safety boundary not already configured.
+
+
+Fingerprinting considerations of `isSessionSupported()` {#issessionsupported-fingerprinting}
+----------------------------------
+Because {{XRSystem/isSessionSupported()}} can be called without user activation it may be used as a fingerprinting vector despite the limited amount of information it reports.
+
+<dfn enum-value for="PermissionName">"xr-session-supported"</dfn> [=powerful feature=] gates access to the {{XRSystem/isSessionSupported()}} API in cases where there are fingerprinting concerns.
+
+The {{PermissionName/"xr-session-supported"}}’s permission-related algorithms and types are defined as follows:
+
+
+<dl>
+<dt>[=permission descriptor type=]</dt>
+<dd>
+
+<pre class="idl">
+dictionary XRSessionSupportedPermissionDescriptor: PermissionDescriptor {
+  XRSessionMode mode;
+};
+</pre>
+
+{{PermissionDescriptor/name}} for {{XRPermissionDescriptor}} is {{PermissionName/"xr-session-supported"}}.
+
+</dd></dl>
+
+{{PermissionName/"xr-session-supported"}} may be granted automatically for some systems based on the criteria below.
+
+A set of user agents is <dfn>indistinguishable by user-agent string</dfn> if they all report the same {{NavigatorID/userAgent}} and {{NavigatorID/appVersion}}. Such classes are typically identified by the browser version and platform/device being run on, but cannot be distinguished by the status of any connected external device. We can use the concept of user agents that are [=indistinguishable by user-agent string=] to properly assess fingerprinting risk.
+
+Some user agents [=indistinguishable by user-agent string=] will <dfn>never support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents running on a model of phone that is known to not meet requirements for mobile AR support.</span> In these cases there is little fingerprinting risk in {{XRSystem/isSessionSupported()}} always reporting the {{XRSessionMode}} is not supported because every such device will consistently report the same value and it's assumed that device type and model can be inferred in other ways, such as through {{NavigatorID/userAgent}}. Thus, on such systems, the user-agent SHOULD automatically deny {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
+
+Other user agents will [=indistinguishable by user-agent string=] <dfn>usually support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents known to support WebXR that run exclusively within VR headsets are likely to support {{XRSessionMode/"immersive-vr"}} sessions unless specifically blocked by the user.</span> In these cases reporting that the {{XRSessionMode}} is not supported, while accurate, would offer more uniquely identifying information about the user. As such reporting that the {{XRSessionMode}} is always available and allowing {{XRSystem/requestSession()}} to fail is more privacy-preserving while likely not being a source of confusion for the user. On such systems, the user-agent SHOULD automatically grant {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
+
+User agents [=indistinguishable by user-agent string=] for which availability of XR capabilities is highly variable, such as desktop systems which support XR peripherals, present the highest fingerprinting risk. User agents on such devices SHOULD NOT automatically grant {{PermissionName/"xr-session-supported"}} in a way that allows the {{isSessionSupported()}} API to provide additional fingerprinting bits. 
+
+
+<div class=note>
+Note: Some acceptable approaches to handle such cases are as follows:
+
+ - Always judging [=explicit consent=] for {{PermissionName/"xr-session-supported"}} (with a potentially cached permissions prompt or similar) when {{XRSystem/isSessionSupported()}} is called.
+ - Automatically granting {{PermissionName/"xr-session-supported"}} but having {{XRSystem/isSessionSupported()}} always report `true` even on platforms which do not consistently have XR capabilities available, regardless of whether or not the appropriate hardware or software is present. This comes at the cost of user ergonomics, as it will cause pages to advertise XR content to users that cannot view it.
+ - Have {{XRSystem/isSessionSupported()}} request [=explicit consent=] for {{PermissionName/"xr-session-supported"}} when the appropriate hardware is present, and when such hardware is _not_ present, return `false` after an appropriately random length of time. In such an implementation content must not be able to distinguish between cases where the user agent was not connected to XR hardware and cases where the user agent was connected to XR hardware but the user declined to provide [=explicit consent=].
+
+</div>
+
+Whatever the technique chosen, it MUST NOT reveal additional knowledge about connected XR hardware without [=explicit consent=].
+
 
 Session {#session}
 =======

--- a/index.bs
+++ b/index.bs
@@ -347,7 +347,7 @@ When this method is invoked, it MUST run the following steps:
         1. Let |device| be the result of [=ensure an immersive XR device is selected|ensuring an immersive XR device is selected=].
         1. If |device| is null, [=/resolve=] |promise| with `false` and abort these steps.
         1. If |device|'s [=list of supported modes=] does not [=list/contain=] |mode|, [=queue a task=] to [=/resolve=] |promise| with `false` and abort these steps.
-        1. [=request permission to use=] the [=powerful feature=] {{PermissionName/"xr-session-supported"}} with {{XRSessionSupportedPermissionDescriptor}} with {{XRSessionSupportedPermissionDescriptor/mode}} equal to |mode|. If it returns {{PermissionState/"denied"}} [=queue a task=] to [=/resolve=] |promise| with `false` and abort these steps.
+        1. [=request permission to use=] the [=powerful feature=] {{PermissionName/"xr-session-supported"}} with {{XRSessionSupportedPermissionDescriptor}} with {{XRSessionSupportedPermissionDescriptor/mode}} equal to |mode|. If it returns {{PermissionState/"denied"}} [=queue a task=] to [=/resolve=] |promise| with `false` and abort these steps. <span class=note>See [[#issessionsupported-fingerprinting|Fingerprinting considerations]] for more information.
         1. [=queue a task=] to [=/resolve=] |promise| with `true`.
 
     </dl>
@@ -593,7 +593,7 @@ Note: {{XRReferenceSpaceType/"local"}} is always included in the [=requested fea
 Note: For example, several VR devices support either configuring a safe boundary for the user to move around within or skipping boundary configuration and operating in a mode where the user is expected to stand in place. Such a device can be considered to be [=capable of supporting=] {{"bounded-floor"}} {{XRReferenceSpace}}s even if they are currently not configured with safety boundaries, because it's expected that the user could configure the device appropriately if the experience required it. This is to allow user agents to avoid fully initializing the [=XRSession/XR device=] or waiting for the user's environment to be recognized prior to [=resolve the requested features|resolving the requested features=] if desired. If, however, the user agent knows that the boundary state at the time the session is requested without additional initialization it may choose to reject the {{"bounded-floor"}} feature if the safety boundary not already configured.
 
 
-Fingerprinting considerations of `isSessionSupported()` {#issessionsupported-fingerprinting}
+Fingerprinting considerations of {{XRSystem/isSessionSupported()}} {#issessionsupported-fingerprinting}
 ----------------------------------
 Because {{XRSystem/isSessionSupported()}} can be called without user activation it may be used as a fingerprinting vector despite the limited amount of information it reports.
 

--- a/index.bs
+++ b/index.bs
@@ -616,7 +616,7 @@ dictionary XRSessionSupportedPermissionDescriptor: PermissionDescriptor {
 
 </dd></dl>
 
-### Automatic granting of {{PermissionName/"xr-session-supported"}} ### {#automatic-granting-xr-session-supported}
+### Considerations for when to automatically grant {{PermissionName/"xr-session-supported"}} ### {#automatic-granting-xr-session-supported}
 
 <section class="non-normative">
 


### PR DESCRIPTION
Fixes any leftover issues from https://github.com/immersive-web/webxr/pull/1124

After discussion with @pes10k and @toji , we've decided that the best path forward is to keep the normative part of the spec simple and move the pref autogranting to a separate non normative section.

(We should probably move this into the "fingerprinting" section at the bottom of the spec, but that also needs some cleanup)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1146.html" title="Last updated on Dec 2, 2020, 1:33 AM UTC (f793a82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1146/62a3c1f...Manishearth:f793a82.html" title="Last updated on Dec 2, 2020, 1:33 AM UTC (f793a82)">Diff</a>