### PR TITLE
Mark context isolation/fingerprinting sections as stable, reorganize

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -592,60 +592,6 @@ Note: {{XRReferenceSpaceType/"local"}} is always included in the [=requested fea
 
 Note: For example, several VR devices support either configuring a safe boundary for the user to move around within or skipping boundary configuration and operating in a mode where the user is expected to stand in place. Such a device can be considered to be [=capable of supporting=] {{"bounded-floor"}} {{XRReferenceSpace}}s even if they are currently not configured with safety boundaries, because it's expected that the user could configure the device appropriately if the experience required it. This is to allow user agents to avoid fully initializing the [=XRSession/XR device=] or waiting for the user's environment to be recognized prior to [=resolve the requested features|resolving the requested features=] if desired. If, however, the user agent knows that the boundary state at the time the session is requested without additional initialization it may choose to reject the {{"bounded-floor"}} feature if the safety boundary not already configured.
 
-
-Fingerprinting considerations of {{XRSystem/isSessionSupported()}} {#issessionsupported-fingerprinting}
-----------------------------------
-Because {{XRSystem/isSessionSupported()}} can be called without user activation it may be used as a fingerprinting vector.
-
-<dfn enum-value for="PermissionName">"xr-session-supported"</dfn> [=powerful feature=] gates access to the {{XRSystem/isSessionSupported()}} API.
-
-The {{PermissionName/"xr-session-supported"}}’s permission-related algorithms and types are defined as follows:
-
-
-<dl>
-<dt>[=permission descriptor type=]</dt>
-<dd>
-
-<pre class="idl">
-dictionary XRSessionSupportedPermissionDescriptor: PermissionDescriptor {
-  XRSessionMode mode;
-};
-</pre>
-
-{{PermissionDescriptor/name}} for {{XRPermissionDescriptor}} is {{PermissionName/"xr-session-supported"}}.
-
-</dd></dl>
-
-### Considerations for when to automatically grant {{PermissionName/"xr-session-supported"}} ### {#automatic-granting-xr-session-supported}
-
-<section class="non-normative">
-
-There is often tension between privacy and personalization on the Web. This section provides guidance on where that tradeoff can be circumscribed, and when the user agent can describe the browser's WebXR capabilities to a site via {{XRSystem/isSessionSupported()}} without any privacy reduction.
-
-{{PermissionName/"xr-session-supported"}} may be granted automatically for some systems based on the criteria below. This can provide a better user experience and mitigate permissions fatigue.
-
-A set of user agents is <dfn>indistinguishable by user-agent string</dfn> if they all report the same {{NavigatorID/userAgent}} and {{NavigatorID/appVersion}}. Such classes are typically identified by the browser version and platform/device being run on, but cannot be distinguished by the status of any connected external device. We can use the concept of user agents that are [=indistinguishable by user-agent string=] to properly assess fingerprinting risk.
-
-Some user agents [=indistinguishable by user-agent string=] will <dfn>never support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents running on a model of phone that is known to not meet requirements for mobile AR support.</span> In these cases there is little fingerprinting risk in {{XRSystem/isSessionSupported()}} always reporting the {{XRSessionMode}} is not supported because every such device will consistently report the same value and it's assumed that device type and model can be inferred in other ways, such as through {{NavigatorID/userAgent}}. Thus, on such systems, the user-agent should automatically deny {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
-
-Other user agents will [=indistinguishable by user-agent string=] <dfn>usually support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents known to support WebXR that run exclusively within VR headsets are likely to support {{XRSessionMode/"immersive-vr"}} sessions unless specifically blocked by the user.</span> In these cases reporting that the {{XRSessionMode}} is not supported, while accurate, would offer more uniquely identifying information about the user. As such reporting that the {{XRSessionMode}} is always available and allowing {{XRSystem/requestSession()}} to fail is more privacy-preserving while likely not being a source of confusion for the user. On such systems, the user-agent should automatically grant {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
-
-User agents [=indistinguishable by user-agent string=] for which availability of XR capabilities is highly variable, such as desktop systems which support XR peripherals, present the highest fingerprinting risk. User agents on such devices should not automatically grant {{PermissionName/"xr-session-supported"}} in a way that allows the {{isSessionSupported()}} API to provide additional fingerprinting bits. 
-
-
-<div class=note>
-Note: Some acceptable approaches to handle such cases are as follows:
-
- - Always judging [=explicit consent=] for {{PermissionName/"xr-session-supported"}} (with a potentially cached permissions prompt or similar) when {{XRSystem/isSessionSupported()}} is called.
- - Automatically granting {{PermissionName/"xr-session-supported"}} but having {{XRSystem/isSessionSupported()}} always report `true` even on platforms which do not consistently have XR capabilities available, regardless of whether or not the appropriate hardware or software is present. This comes at the cost of user ergonomics, as it will cause pages to advertise XR content to users that cannot view it.
- - Have {{XRSystem/isSessionSupported()}} request [=explicit consent=] for {{PermissionName/"xr-session-supported"}} when the appropriate hardware is present, and when such hardware is _not_ present, return `false` after an appropriately random length of time. In such an implementation content must not be able to distinguish between cases where the user agent was not connected to XR hardware and cases where the user agent was connected to XR hardware but the user declined to provide [=explicit consent=].
-
-</div>
-
-Whatever the technique chosen, it should not reveal additional knowledge about connected XR hardware without [=explicit consent=].
-
-</section>
-
 Session {#session}
 =======
 
@@ -2663,6 +2609,60 @@ Fingerprinting {#fingerprinting-security}
 --------------
 
 Given that the API describes hardware available to the user and its capabilities it will inevitably provide additional surface area for fingerprinting. While it's impossible to completely avoid this, user agents should take steps to mitigate the issue. This spec limits reporting of available hardware to only a single device at a time, which prevents using the rare cases of multiple headsets being connected as a fingerprinting signal. Also, the devices that are reported have no string identifiers and expose very little information about the devices capabilities until an XRSession is created, which requires additional protections when [=sensitive information=] will be exposed.
+
+
+Fingerprinting considerations of {{XRSystem/isSessionSupported()}} {#issessionsupported-fingerprinting}
+----------------------------------
+Because {{XRSystem/isSessionSupported()}} can be called without user activation it may be used as a fingerprinting vector.
+
+<dfn enum-value for="PermissionName">"xr-session-supported"</dfn> [=powerful feature=] gates access to the {{XRSystem/isSessionSupported()}} API.
+
+The {{PermissionName/"xr-session-supported"}}’s permission-related algorithms and types are defined as follows:
+
+
+<dl>
+<dt>[=permission descriptor type=]</dt>
+<dd>
+
+<pre class="idl">
+dictionary XRSessionSupportedPermissionDescriptor: PermissionDescriptor {
+  XRSessionMode mode;
+};
+</pre>
+
+{{PermissionDescriptor/name}} for {{XRPermissionDescriptor}} is {{PermissionName/"xr-session-supported"}}.
+
+</dd></dl>
+
+### Considerations for when to automatically grant {{PermissionName/"xr-session-supported"}} ### {#automatic-granting-xr-session-supported}
+
+<section class="non-normative">
+
+There is often tension between privacy and personalization on the Web. This section provides guidance on where that tradeoff can be circumscribed, and when the user agent can describe the browser's WebXR capabilities to a site via {{XRSystem/isSessionSupported()}} without any privacy reduction.
+
+{{PermissionName/"xr-session-supported"}} may be granted automatically for some systems based on the criteria below. This can provide a better user experience and mitigate permissions fatigue.
+
+A set of user agents is <dfn>indistinguishable by user-agent string</dfn> if they all report the same {{NavigatorID/userAgent}} and {{NavigatorID/appVersion}}. Such classes are typically identified by the browser version and platform/device being run on, but cannot be distinguished by the status of any connected external device. We can use the concept of user agents that are [=indistinguishable by user-agent string=] to properly assess fingerprinting risk.
+
+Some user agents [=indistinguishable by user-agent string=] will <dfn>never support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents running on a model of phone that is known to not meet requirements for mobile AR support.</span> In these cases there is little fingerprinting risk in {{XRSystem/isSessionSupported()}} always reporting the {{XRSessionMode}} is not supported because every such device will consistently report the same value and it's assumed that device type and model can be inferred in other ways, such as through {{NavigatorID/userAgent}}. Thus, on such systems, the user-agent should automatically deny {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
+
+Other user agents will [=indistinguishable by user-agent string=] <dfn>usually support</dfn> sessions of a given {{XRSessionMode}}. <span class='note'>For example: User agents known to support WebXR that run exclusively within VR headsets are likely to support {{XRSessionMode/"immersive-vr"}} sessions unless specifically blocked by the user.</span> In these cases reporting that the {{XRSessionMode}} is not supported, while accurate, would offer more uniquely identifying information about the user. As such reporting that the {{XRSessionMode}} is always available and allowing {{XRSystem/requestSession()}} to fail is more privacy-preserving while likely not being a source of confusion for the user. On such systems, the user-agent should automatically grant {{PermissionName/"xr-session-supported"}} for the relevant {{XRSessionMode}}.
+
+User agents [=indistinguishable by user-agent string=] for which availability of XR capabilities is highly variable, such as desktop systems which support XR peripherals, present the highest fingerprinting risk. User agents on such devices should not automatically grant {{PermissionName/"xr-session-supported"}} in a way that allows the {{isSessionSupported()}} API to provide additional fingerprinting bits. 
+
+
+<div class=note>
+Note: Some acceptable approaches to handle such cases are as follows:
+
+ - Always judging [=explicit consent=] for {{PermissionName/"xr-session-supported"}} (with a potentially cached permissions prompt or similar) when {{XRSystem/isSessionSupported()}} is called.
+ - Automatically granting {{PermissionName/"xr-session-supported"}} but having {{XRSystem/isSessionSupported()}} always report `true` even on platforms which do not consistently have XR capabilities available, regardless of whether or not the appropriate hardware or software is present. This comes at the cost of user ergonomics, as it will cause pages to advertise XR content to users that cannot view it.
+ - Have {{XRSystem/isSessionSupported()}} request [=explicit consent=] for {{PermissionName/"xr-session-supported"}} when the appropriate hardware is present, and when such hardware is _not_ present, return `false` after an appropriately random length of time. In such an implementation content must not be able to distinguish between cases where the user agent was not connected to XR hardware and cases where the user agent was connected to XR hardware but the user declined to provide [=explicit consent=].
+
+</div>
+
+Whatever the technique chosen, it should not reveal additional knowledge about connected XR hardware without [=explicit consent=].
+
+</section>
 
 
 Integrations {#integrations}

--- a/index.bs
+++ b/index.bs
@@ -156,19 +156,19 @@ spec: requestidlecallback; urlPrefix: https://w3c.github.io/requestidlecallback/
   .tg th {
     border-style: solid;
     border-width: 1px;
-    background: #90b8de;
+    background: var(--def-bg);
     color: #fff;
     font-family: sans-serif;
     font-weight: bold;
-    border-color: grey;
+    border-color: var(--def-border);
   }
   .tg td {
     padding: 4px 5px;
-    background-color: rgb(221, 238, 255);
+    background-color: var(--def-bg);
     font-family: monospace;
     border-style: solid;
     border-width: 1px;
-    border-color: grey;
+    border-color: var(--def-border);
     overflow: hidden;
     word-break: normal;
   }
@@ -2826,7 +2826,7 @@ Thank you to the following individuals for their contributions the WebXR Device 
   * <a href="mailto:nb@8thwall.com">Nicholas Butko</a> (<a href="https://8thwall.com">8th Wall</a>)
   * <a href="mailto:artyom@fb.com">Artem Bolgar</a> (<a href="https://about.fb.com/company-info/">Facebook, Inc.</a>)
   * <a href="mailto:cwilso@google.com">Chris Wilson</a> (<a href="https://google.com/">Google</a>)
-  * <a href="mailto:alan@metavrse.com">Alan Smithson</a> (<a href="https://MetaVRse.com">MetaVRse</a>)
+  * <a href="mailto:alanvartavrse.com">Alan Smithson</a> (<a href="https://MetaVRse.com">MetaVRse</a>)
   * <a href="mailto:jmarinacci@mozilla.com">Josh Marinacci</a> (<a href="https://mozilla.org/">Mozilla</a>)
   * <a href="mailto:loc@locdao.com">Loc Dao</a> (<a href="https://nfb.ca/interactive">National Film Board of Canada</a>)
   * <a href="mailto:ningxin.hu@intel.com">Ningxin Hu</a> (<a href="https://www.intel.com/">Intel</a>)

--- a/index.bs
+++ b/index.bs
@@ -2649,8 +2649,6 @@ If the virtual environment does not consistently track the user's head motion wi
 
 Additionally, page content has the ability to make users uncomfortable in ways not related to performance. Badly applied tracking, strobing colors, and content intended to offend, frighten, or intimidate are examples of content which may cause the user to want to quickly exit the XR experience. Removing the XR device in these cases may not always be a fast or practical option. To accommodate this the user agent MUST provide users with an action, such as pressing a reserved hardware button or performing a gesture, that escapes out of WebXR content and displays the user agent's [=trusted UI=].
 
-<section class="unstable">
-
 
 Context Isolation {#contextisolation-security}
 -----------------
@@ -2665,7 +2663,7 @@ Fingerprinting {#fingerprinting-security}
 --------------
 
 Given that the API describes hardware available to the user and its capabilities it will inevitably provide additional surface area for fingerprinting. While it's impossible to completely avoid this, user agents should take steps to mitigate the issue. This spec limits reporting of available hardware to only a single device at a time, which prevents using the rare cases of multiple headsets being connected as a fingerprinting signal. Also, the devices that are reported have no string identifiers and expose very little information about the devices capabilities until an XRSession is created, which requires additional protections when [=sensitive information=] will be exposed.
-</section>
+
 
 Integrations {#integrations}
 ============


### PR DESCRIPTION
This stabilizes the last unstable section of the spec, one of the CR blockers. It does not seem to me that the contents of these sections are still up for debate, though we should probably check in with the group.

This also moves the `isSessionSupported()` fingerprinting section to the privacy/security section, now that the main fingerprinting section is stable.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/webxr/pull/1153.html" title="Last updated on Dec 27, 2020, 7:41 PM UTC (b660c1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1153/9edd25f...Manishearth:b660c1f.html" title="Last updated on Dec 27, 2020, 7:41 PM UTC (b660c1f)">Diff</a>