### PR TITLE
Fix ref. to XR device's set of granted features

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2770,7 +2770,7 @@ To <dfn lt="request the xr permission">request the "xr" permission</dfn> with an
       1. If a clear signal of [=user intent=] to enable |feature| has not been determined, continue to the next entry.
       1. If |feature| is not in |granted|, append |feature| to |granted|.
   1. Set |status|'s {{XRPermissionStatus/granted}} to |granted|.
-  1. Add all elements of |granted| to |device|'s [=set of granted features=] for |mode|.
+  1. Add all elements of |granted| to |device|'s [=XR device/set of granted features=] for |mode|.
   1. Set |status|'s {{PermissionStatus/state}} to {{PermissionState/"granted"}}.
 
 Note: The user agent has the freedom to batch up permissions prompts for all requested features when gauging if there is a clear signal of [=user intent=], but it is also allowed to show them one at a time.


### PR DESCRIPTION
Fix reference to XR device's set of granted features - bikeshed by default seems to pick the one belonging to XRSession (clicking on https://immersive-web.github.io/webxr/#xrsession-set-of-granted-features shows a link to section 14.2, and takes me to this algorithm step).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bialpio/webxr/pull/1204.html" title="Last updated on Jun 17, 2021, 9:13 PM UTC (da0f566)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1204/cbd417a...bialpio:da0f566.html" title="Last updated on Jun 17, 2021, 9:13 PM UTC (da0f566)">Diff</a>