### PR TITLE
Add XRFrame.predictedDisplayTime

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -990,6 +990,7 @@ When an {{XRSession}} |session| receives updated [=viewer=] state for timestamp 
     1. Let |now| be the [=current high resolution time=].
     1. Let |frame| be |session|'s [=XRSession/animation frame=].
     1. Set |frame|'s [=XRFrame/time=] to |frameTime|.
+    1. Set |frame|'s [predictedDisplayTime] to the timestamp when the [=XR Compositor=] is expected to display content drawn during this [=XR animation frame=].
     1. For each |view| in [=XRSession/list of views=], set |view|'s [=view/viewport modifiable=] flag to true.
     1. If the [=view/active=] flag of any [=view=] in the [=XRSession/list of views=] has changed since the last [=XR animation frame=], [=update the viewports=].
     1. If the frame [=should be rendered=] for |session|:
@@ -1033,7 +1034,7 @@ window.requestAnimationFrame(onWindowAnimationFrame);
 
 function onXRAnimationFrame(time, xrFrame) {
   xrSession.requestAnimationFrame(onXRAnimationFrame);
-  renderFrame(time, xrFrame);
+  renderFrame(xrFrame.predictedDisplayTime, xrFrame);
 }
 
 function renderFrame(time, xrFrame) {
@@ -1075,6 +1076,7 @@ An {{XRFrame}} represents a snapshot of the state of all of the tracked objects 
 <pre class="idl">
 [SecureContext, Exposed=Window] interface XRFrame {
   [SameObject] readonly attribute XRSession session;
+  readonly attribute DOMHighResTimeStamp predictedDisplayTime;
 
   XRViewerPose? getViewerPose(XRReferenceSpace referenceSpace);
   XRPose? getPose(XRSpace space, XRSpace baseSpace);
@@ -1084,6 +1086,14 @@ An {{XRFrame}} represents a snapshot of the state of all of the tracked objects 
 Each {{XRFrame}} has an <dfn for="XRFrame">active</dfn> boolean which is initially set to `false`, and an <dfn for="XRFrame">animationFrame</dfn> boolean which is initially set to `false`.
 
 The <dfn attribute for="XRFrame">session</dfn> attribute returns the {{XRSession}} that produced the {{XRFrame}}.
+
+The <dfn attribute for="XRFrame">predictedDisplayTime</dfn> attribute returns the {{DOMHighResTimeStamp}} that represents the point in time at which a rendered frame submitted for this {{XRFrame}} is expected to show up on the devices display.
+
+<div class=note>
+The [=XRFrame/predictedDisplayTime=] is intended to allow rendering an animated XR scene in the state that it should be in when the frame is displayed rather than when the {{XRSession/requestAnimationFrame()}} callback was scheduled or when it was executed.
+
+The [=XRFrame/predictedDisplayTime=] is not intended be used to infer how much time the application has for rendering, as the [=XR Compositor=] typically has to do extra processing after the frame is submitted. If the experience assumes that it can process up to [=XRFrame/predictedDisplayTime=], the [=XR Compositor=] will not be able to make use of the submitted frames, and the application would not make target framerate.
+</div>
 
 Each {{XRFrame}} represents the state of all tracked objects for a given <dfn for="XRFrame">time</dfn>, and either stores or is able to query concrete information about this state at the [=XRFrame/time=].
 


### PR DESCRIPTION
Hi everyone,

Following up on #1211 and the discussion in the latest meeting, here's a proposal/draft for the `XRFrame.predictedDisplayTime` property.

I adapted the main loop rendering example to demonstrate the use of `predictedDisplayTime`. While the explicit time parameter here is redundant, it shows a clear difference to the window rAF.

This spec currently expects the implementor to understand how the display time could be predicted rather than providing an algorithm. I'm uncertain if it is okay to assume that the underlying implementation/SDK has this value available (as discussed, [it is for OpenXR](https://www.khronos.org/registry/OpenXR/specs/1.0/man/html/openxr.html#XrFrameState)). Could it be useful to add a suggestion for what to set the value to if it is not?

Best,
Jonathan


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Squareys/webxr/pull/1217.html" title="Last updated on Sep 18, 2021, 10:00 AM UTC (0270aba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1217/ffe5171...Squareys:0270aba.html" title="Last updated on Sep 18, 2021, 10:00 AM UTC (0270aba)">Diff</a>