### PR TITLE
fix for WD 20210824

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,7 +7,7 @@ TR: https://www.w3.org/TR/webxr/
 ED: https://immersive-web.github.io/webxr/
 Previous Version: https://www.w3.org/TR/2020/WD-webxr-20200724/
 Repository: immersive-web/webxr
-Level: 1
+Level: none
 Mailing List Archives: https://lists.w3.org/Archives/Public/public-immersive-web/
 
 !Participate: <a href="https://github.com/immersive-web/webxr/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/webxr/issues">open issues</a>)


### PR DESCRIPTION
we currently don't have level for webxr spec, Level line should point none instead of 1


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/webxr/pull/1218.html" title="Last updated on Aug 24, 2021, 4:15 PM UTC (99fc03b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1218/b1b191f...himorin:99fc03b.html" title="Last updated on Aug 24, 2021, 4:15 PM UTC (99fc03b)">Diff</a>