### PR TITLE
fixed links in header

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11,13 +11,13 @@ Level: none
 Mailing List Archives: https://lists.w3.org/Archives/Public/public-immersive-web/
 
 !Participate: <a href="https://github.com/immersive-web/webxr/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/webxr/issues">open issues</a>)
-!Participate: <a href="https://lists.w3.org/Archives/Public/public-immersive-web/">Mailing list archive</a>
+!Participate: <a href="https://lists.w3.org/Archives/Public/public-immersive-web-wg/">Mailing list archive</a>
 !Participate: <a href="irc://irc.w3.org:6665/">W3C's #immersive-web IRC</a>
 
-Editor: Brandon Jones 87824, Google http://google.com/, bajones@google.com
+Editor: Brandon Jones 87824, Google https://google.com/, bajones@google.com
 Former Editor: Nell Waliczek 93109, Amazon [Microsoft until 2018] https://amazon.com/, nhw@amazon.com
 Editor: Manish Goregaokar 109489, Google [Mozilla until 2020], manishearth@google.com
-Editor: Rik Cabanier 106988, Facebook http://oculus.com, cabanier@fb.com
+Editor: Rik Cabanier 106988, Facebook https://oculus.com, cabanier@fb.com
 
 Abstract: This specification describes support for accessing virtual reality (VR) and augmented reality (AR) devices, including sensors and head-mounted displays, on the Web.
 


### PR DESCRIPTION
fixing links in header part. WG uses a mail list `public-immersive-web-wg` but not `public-immersive-web` which is for CG.
also replaced affiliation links to https.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/webxr/pull/1224.html" title="Last updated on Sep 27, 2021, 8:53 AM UTC (da3acbb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1224/4e0420b...himorin:da3acbb.html" title="Last updated on Sep 27, 2021, 8:53 AM UTC (da3acbb)">Diff</a>