### PR TITLE
fixed link in header (forgot one)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,7 +7,7 @@ TR: https://www.w3.org/TR/webxr/
 ED: https://immersive-web.github.io/webxr/
 Repository: immersive-web/webxr
 Level: none
-Mailing List Archives: https://lists.w3.org/Archives/Public/public-immersive-web/
+Mailing List Archives: https://lists.w3.org/Archives/Public/public-immersive-web-wg/
 
 !Participate: <a href="https://github.com/immersive-web/webxr/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/webxr/issues">open issues</a>)
 !Participate: <a href="https://lists.w3.org/Archives/Public/public-immersive-web-wg/">Mailing list archive</a>


### PR DESCRIPTION
as https://github.com/immersive-web/webxr/pull/1224 (forgot one additional line)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/webxr/pull/1229.html" title="Last updated on Sep 30, 2021, 6:54 AM UTC (979b897)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1229/b5892f0...himorin:979b897.html" title="Last updated on Sep 30, 2021, 6:54 AM UTC (979b897)">Diff</a>