### PR TITLE
[editorial] copy SVG height into img

### DIFF
--- a/images/rigid_matrix.svg
+++ b/images/rigid_matrix.svg
@@ -1,4 +1,4 @@
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="55.928ex" height="13.509ex" style="" viewBox="0 -3159.4 24080 5816.5" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" aria-labelledby="MathJax-SVG-1-Title">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="55.928ex" height="13.510ex" style="" viewBox="0 -3159.4 24080 5817" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" aria-labelledby="MathJax-SVG-1-Title">
 <!--
     \begin{bmatrix}
     1 - 2 (q_y^2 + q_z^2) &

--- a/images/rotation_matrix.svg
+++ b/images/rotation_matrix.svg
@@ -1,4 +1,4 @@
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="55.761ex" height="13.509ex" style="" viewBox="0 -3159.4 24008 5816.5" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" aria-labelledby="MathJax-SVG-1-Title">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="55.761ex" height="13.510ex" style="" viewBox="0 -3159.4 24008 5817" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" aria-labelledby="MathJax-SVG-1-Title">
 <!--
     \begin{bmatrix}
     1 - 2 (q_y^2 + q_z^2) &

--- a/images/translation_matrix.svg
+++ b/images/translation_matrix.svg
@@ -1,4 +1,4 @@
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="15.637ex" height="12.509ex" style="" viewBox="0 -2944.1 6732.5 5385.9" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" aria-labelledby="MathJax-SVG-1-Title">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="15.638ex" height="12.509ex" style="" viewBox="0 -2944.1 6733 5386" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" aria-labelledby="MathJax-SVG-1-Title">
 <!--
     \begin{bmatrix}
     1 & 0 & 0 & x \\

--- a/index.bs
+++ b/index.bs
@@ -1725,13 +1725,13 @@ To <dfn for="XRRigidTransform">obtain the matrix</dfn> for a given {{XRRigidTran
     1. If the operation {{IsDetachedBuffer}} on [=XRRigidTransform/internal matrix=] is `false`, return |transform|'s [=XRRigidTransform/internal matrix=].
   1. Let |translation| be a new [=matrix=] which is a column-vector translation matrix corresponding to {{XRRigidTransform/position}}. Mathematically, if {{XRRigidTransform/position}} is `(x, y, z)`, this matrix is
 
-        <img src="images/translation_matrix.svg" alt="Mathematical expression for column-vector translation matrix" />
+        <img src="images/translation_matrix.svg" height="12.509ex" alt="Mathematical expression for column-vector translation matrix" />
   1. Let |rotation| be a new [=matrix=] which is a column-vector rotation matrix corresponding to {{XRRigidTransform/orientation}}. Mathematically, if {{XRRigidTransform/orientation}} is the unit quaternion (<code>q<sub>x</sub>, q<sub>y</sub>, q<sub>z</sub>, q<sub>w</sub></code>), this matrix is
 
-        <img src="images/rotation_matrix.svg" alt="Mathematical expression for column-vector rotation matrix" />
+        <img src="images/rotation_matrix.svg" height="13.509ex" alt="Mathematical expression for column-vector rotation matrix" />
   1. Set |transform|'s [=XRRigidTransform/internal matrix=] to a [=new=] {{Float32Array}} in the [=relevant realm=] of |transform| set to the result of multiplying |translation| and |rotation| with |translation| on the left (`translation * rotation`) in the [=relevant realm=] of |transform|. Mathematically, this matrix is
 
-       <img src="images/rigid_matrix.svg" alt="Mathematical expression for matrix of multiplying translation and rotation with translation on the left" />
+       <img src="images/rigid_matrix.svg" height="13.509ex" alt="Mathematical expression for matrix of multiplying translation and rotation with translation on the left" />
   1. Return |transform|'s [=XRRigidTransform/internal matrix=].
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1725,13 +1725,13 @@ To <dfn for="XRRigidTransform">obtain the matrix</dfn> for a given {{XRRigidTran
     1. If the operation {{IsDetachedBuffer}} on [=XRRigidTransform/internal matrix=] is `false`, return |transform|'s [=XRRigidTransform/internal matrix=].
   1. Let |translation| be a new [=matrix=] which is a column-vector translation matrix corresponding to {{XRRigidTransform/position}}. Mathematically, if {{XRRigidTransform/position}} is `(x, y, z)`, this matrix is
 
-        <img src="images/translation_matrix.svg" height="12.509ex" alt="Mathematical expression for column-vector translation matrix" />
+        <img src="images/translation_matrix.svg" width="6733" height="5386" style="height: 6em; width: auto;" alt="Mathematical expression for column-vector translation matrix" />
   1. Let |rotation| be a new [=matrix=] which is a column-vector rotation matrix corresponding to {{XRRigidTransform/orientation}}. Mathematically, if {{XRRigidTransform/orientation}} is the unit quaternion (<code>q<sub>x</sub>, q<sub>y</sub>, q<sub>z</sub>, q<sub>w</sub></code>), this matrix is
 
-        <img src="images/rotation_matrix.svg" height="13.509ex" alt="Mathematical expression for column-vector rotation matrix" />
+        <img src="images/rotation_matrix.svg" width="24008" height="5817" style="height: 6em; width: auto" alt="Mathematical expression for column-vector rotation matrix" />
   1. Set |transform|'s [=XRRigidTransform/internal matrix=] to a [=new=] {{Float32Array}} in the [=relevant realm=] of |transform| set to the result of multiplying |translation| and |rotation| with |translation| on the left (`translation * rotation`) in the [=relevant realm=] of |transform|. Mathematically, this matrix is
 
-       <img src="images/rigid_matrix.svg" height="13.509ex" alt="Mathematical expression for matrix of multiplying translation and rotation with translation on the left" />
+       <img src="images/rigid_matrix.svg" width="24080" height="5817" style="height: 6em; width: auto" alt="Mathematical expression for matrix of multiplying translation and rotation with translation on the left" />
   1. Return |transform|'s [=XRRigidTransform/internal matrix=].
 
 </div>


### PR DESCRIPTION
bikeshed does not pick image size for SVG (see also: https://github.com/tabatkins/bikeshed/issues/2042)
This PR copies height attribute from SVG images into source.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/webxr/pull/1246.html" title="Last updated on Dec 24, 2021, 5:47 AM UTC (e5e10b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1246/08e6fab...himorin:e5e10b4.html" title="Last updated on Dec 24, 2021, 5:47 AM UTC (e5e10b4)">Diff</a>