### PR TITLE
Clarify getPose behavior with visibile-blurred

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1259,6 +1259,7 @@ To <dfn>populate the pose</dfn> of an {{XRSpace}} |space| in an {{XRSpace}} |bas
   1. If |space|'s [=XRSpace/session=] does not equal |session|, throw an {{InvalidStateError}} and abort these steps.
   1. If |baseSpace|'s [=XRSpace/session=] does not equal |session|, throw an {{InvalidStateError}} and abort these steps.
   1. Check if [=poses may be reported=] and, if not, throw a {{SecurityError}} and abort these steps.
+  1. If |session|'s {{XRSession/visibilityState}} is {{XRVisibilityState/"visible-blurred"}} and |space| or |baseSpace| is associated with an {{XRInputSource}}, set |pose| to `null` and abort these steps.
   1. Let |limit| be the result of whether [=poses must be limited=] between |space| and |baseSpace|.
   1. Let |transform| be |pose|'s {{XRPose/transform}}.
   1. Query the [=/XR device=]'s tracking system for |space|'s pose relative to |baseSpace| at the |frame|'s [=XRFrame/time=], then perform the following steps:
@@ -2607,7 +2608,7 @@ When based on sensor data, {{XRPose}} and {{XRViewerPose}} will expose [=sensiti
 To determine if <dfn>poses may be reported</dfn> to an {{XRSession}} |session|, the user agent MUST run the following steps:
 
   1. If |session|'s [=relevant global object=] is not the [=current global object=], return `false`.
-  1. If |session|'s {{XRSession/visibilityState}} is not {{XRVisibilityState/"visible"}}, return `false`.
+  1. If |session|'s {{XRSession/visibilityState}} is {{XRVisibilityState/"hidden"}}, return `false`.
   1. Determine if the pose data can be returned as follows:
     <dl class="switch">
       : If the pose data is known by the user agent to not expose fingerprintable sensor data


### PR DESCRIPTION
The "poses may be reported" algorithm previously indicated that poses could only be reported if the visibility state was "visible", but that appears to be a mistake originating from the fact that "visible-blurred" was added later. The description of "visible-blurred" mentioned throttled head poses, so obviously the intention was to allow some poses in that state, just not input poses.

This change alters the "poses may be reported" algorithm to only suppress poses when the visiblity state is "hidden", and adds an explicit step to the "populate the pose" algorithm that prevents input poses from being returned if the visibility state is "visible-blurred"

Thanks @AdaRoseCannon for pointing this out!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/pull/1332.html" title="Last updated on Jun 21, 2023, 4:03 PM UTC (4adf91e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1332/98e6946...4adf91e.html" title="Last updated on Jun 21, 2023, 4:03 PM UTC (4adf91e)">Diff</a>