### PR TITLE
Add allowance for system ui for safety

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -495,6 +495,8 @@ In this document, the term <dfn>inline session</dfn> is synonymous with an {{inl
 
 [=Immersive sessions=] MUST provide some level of [=viewer=] tracking, and content MUST be shown at the proper scale relative to the user and/or the surrounding environment. Additionally, [=Immersive sessions=] MUST be given <dfn>exclusive access</dfn> to the [=immersive XR device=], meaning that while the [=immersive session=] is {{XRVisibilityState/"visible"}} the HTML document is not shown on the [=immersive XR device=]'s display, nor does content from any other source have exclusive access. [=Exclusive access=] does not prevent the user agent from overlaying its own UI, however this UI SHOULD be minimal.
 
+Note: UA may choose to overlay content for accessibility or safety such as guardian boundaries, obstructions or the user's hands when there are no alternative input sources.
+
 Note: Future specifications or modules may expand the definition of [=immersive session=] to include additional session modes.
 
 Note: Examples of ways [=exclusive access=] may be presented include stereo content displayed on a virtual reality headset.


### PR DESCRIPTION
This PR is to give explicit allowances for operating systems to show things for user safety or comfort which either punch through or are show on top of the XR scene.

Examples are if the user doesn't request hands in WebXR but there is no other input then it's more comfortable if the OS shows something.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AdaRoseCannon/webxr/pull/1344.html" title="Last updated on Aug 31, 2023, 7:16 PM UTC (75e7044)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1344/98e6946...AdaRoseCannon:75e7044.html" title="Last updated on Aug 31, 2023, 7:16 PM UTC (75e7044)">Diff</a>