### PR TITLE
Editorial: Update use of WebIDL "invoke a callback function"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1079,8 +1079,7 @@ When an {{XRSession}} |session| receives updated [=viewer=] state for timestamp 
         1. [=XRFrame/Apply frame updates=] for |frame|.
         1. For each |entry| in |session|'s [=list of currently running animation frame callbacks=], in order:
           1. If the |entry|'s [=cancelled=] boolean is `true`, continue to the next entry.
-          1. [=Invoke the Web IDL callback function=] for |entry|, passing |now| and |frame| as the  arguments
-          1. If an exception is thrown, [=report the exception=].
+          1. [=Invoke the Web IDL callback function|Invoke=] |entry| with « |now|, |frame| » and "`report`".
         1. Set |session|'s [=list of currently running animation frame callbacks=] to the empty [=/list=].
         1. Set |frame|'s [=XRFrame/active=] boolean to `false`.
     1. If |session|'s [=pending render state=] is not `null`, [=apply the pending render state=].


### PR DESCRIPTION
This algorithm can now handle the need to report an exception inside an XR animation frame callback.

Part of whatwg/webidl#1425.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeremyroman/webxr/pull/1380.html" title="Last updated on Aug 2, 2024, 6:42 PM UTC (e4afebb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1380/c43a518...jeremyroman:e4afebb.html" title="Last updated on Aug 2, 2024, 6:42 PM UTC (e4afebb)">Diff</a>