### PR TITLE
Remove SameObject attribute from skipRendering

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1841,7 +1841,7 @@ interface XRInputSource {
   [SameObject] readonly attribute XRSpace targetRaySpace;
   [SameObject] readonly attribute XRSpace? gripSpace;
   [SameObject] readonly attribute FrozenArray&lt;DOMString&gt; profiles;
-  [SameObject] readonly attribute boolean skipRendering;
+  readonly attribute boolean skipRendering;
 };
 </pre>
 


### PR DESCRIPTION
Per [WebIDL spec](https://webidl.spec.whatwg.org/#SameObject), 

> The [SameObject] extended attribute must not be used on anything other than a read only attribute whose type is an interface type or object.

`skipRendering` is a boolean, so it isn't eligible. Encountered while updating Servo and getting an error during codegen


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/msub2/webxr/pull/1382.html" title="Last updated on Aug 21, 2024, 6:37 AM UTC (62c3177)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1382/f25c42f...msub2:62c3177.html" title="Last updated on Aug 21, 2024, 6:37 AM UTC (62c3177)">Diff</a>