### PR TITLE
add support for XRVisibilityMaskChangeEvent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1238,16 +1238,19 @@ When this method is invoked, the user agent MUST run the following steps:
   1. [=Populate the pose=] of |session|'s [=XRSession/viewer reference space=] in |referenceSpace| at the time represented by |frame| into |pose|, with `force emulation` set to `true`.
   1. If |pose| is `null` return `null`.
   1. Let |xrviews| be an empty [=/list=].
+  1. Let |offset| be `0`.
   1. For each [=view/active=] [=view=] |view| in the [=XRSession/list of views=] on {{XRFrame/session}}, perform the following steps:
       1. Let |xrview| be a new {{XRView}} object in the [=relevant realm=] of |session|.
       1. Initialize |xrview|'s [=XRView/underlying view=] to |view|.
       1. Initialize |xrview|'s {{XRView/eye}} to |view|'s [=view/eye=].
+      1. Initialize |xrview|'s {{XRView/index}} to |offset|.
       1. Initialize |xrview|'s [=XRView/frame=] to |frame|.
       1. Initialize |xrview|'s [=XRView/session=] to |session|.
       1. Initialize |xrview|'s [=view/reference space=] to |referenceSpace|.
-      1. Let |offset| be an [=new=] {{XRRigidTransform}} object equal to the [=view offset=] of |view| in the [=relevant realm=] of |session|.
-      1. Set |xrview|'s {{XRViewGeometry/transform}} property to the result of [=multiply transforms|multiplying=] the {{XRViewerPose}}'s {{XRPose/transform}} by the |offset| transform in the relevant realm of |session|
-      1. [=list/Append=] |xrview| to |xrviews|
+      1. Let |viewtransform| be an [=new=] {{XRRigidTransform}} object equal to the [=view offset=] of |view| in the [=relevant realm=] of |session|.
+      1. Set |xrview|'s {{XRViewGeometry/transform}} property to the result of [=multiply transforms|multiplying=] the {{XRViewerPose}}'s {{XRPose/transform}} by the |viewtransform| transform in the relevant realm of |session|.
+      1. [=list/Append=] |xrview| to |xrviews|.
+      1. Increase |offset| by `1`.
   1. Set |pose|'s {{XRViewerPose/views}} to |xrviews|
   1. Return |pose|.
 
@@ -1587,7 +1590,7 @@ The {{XRViewGeometry/transform}} is given in it's [=view/reference space=].
 
 The <dfn attribute for="XRView">eye</dfn> attribute describes the [=view/eye=] of the underlying [=view=]. This attribute's primary purpose is to ensure that pre-rendered stereo content can present the correct portion of the content to the correct eye.
 
-The <dfn attribute for="XRView">index</dfn> attribute describes a unique offet of this {{XRView}}. This MUST be used by the experience to identify the {{XRView}} for each {{XREye}}.
+The <dfn attribute for="XRView">index</dfn> attribute describes the offet of this {{XRView}} when it is return in the {{XRViewerPose/views}} array by {{XRFrame/getViewerPose()}}. 
 
 The optional <dfn attribute for="XRView">recommendedViewportScale</dfn> attribute contains a UA-recommended viewport scale value that the application can use for a {{XRView/requestViewportScale()}} call to configure dynamic viewport scaling. It is `null` if the system does not implement a heuristic or method for determining a recommended scale. If not null, the value MUST be a numeric value greater than 0.0 and less than or equal to 1.0, and MUST be [=quantization|quantized=] to avoid providing detailed performance or GPU utilization data.
 
@@ -2615,6 +2618,7 @@ interface XRVisibilityMaskChangeEvent : Event {
 dictionary XRVisibilityMaskChangeEventInit : EventInit {
   required XRSession session;
   required XREye eye;
+  required unsigned long index;
   required Float32Array vertices;
   required Uint32Array indices;
 };
@@ -2624,7 +2628,7 @@ The <dfn attribute for="XRVisibilityMaskChangeEvent">session</dfn> attribute ind
 
 The <dfn attribute for="XRVisibilityMaskChangeEvent">eye</dfn> attribute indicates which {{XREye}} the mask applies to.
 
-The <dfn attribute for="XRVisibilityMaskChangeEvent">index</dfn> attribute indicates which {{XRView/index}} the mask applies to.
+The <dfn attribute for="XRVisibilityMaskChangeEvent">index</dfn> attribute indicates the offset into the [=XRSession/list of views=] of the {{XRView}} that this mask applies to.
 
 The <dfn attribute for="XRVisibilityMaskChangeEvent">vertices</dfn> attribute is a [=/list=] of <code>X</code>, <code>Y</code> coordinates. The experience MUST assume that the <code>Z</code> coordinate is <code>-1</code>. Each <code>X</code>, <code>Y</code>, <code>Z</code> coordinate describes a vertex. 
 If this array is empty, the whole region of the {{XRView}} SHOULD be drawn.


### PR DESCRIPTION
This introduces an event that is fired when the visibility mask changes. See https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_KHR_visibility_mask for the OpenXR equivalent.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cabanier/webxr/pull/1412.html" title="Last updated on Sep 15, 2025, 4:58 PM UTC (09a5e34)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr/1412/16ffa1e...cabanier:09a5e34.html" title="Last updated on Sep 15, 2025, 4:58 PM UTC (09a5e34)">Diff</a>