### PR TITLE
fix: Update HTTP to HTTPS and fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebXR Device API Specification
 
-[![Build Status](https://travis-ci.org/immersive-web/webxr.svg?branch=master)](https://travis-ci.org/immersive-web/webxr)
+[![Build Status](https://github.com/immersive-web/webxr/actions/workflows/auto-publish.yml/badge.svg)](https://github.com/immersive-web/webxr/actions/workflows/auto-publish.yml)
 
 The WebXR device API is for accessing virtual reality (VR) and augmented reality (AR) devices, including sensors and head-mounted displays on the Web. 
 

--- a/build.js
+++ b/build.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const INPUT_PATH = 'index.bs';
 const OUTPUT_PATH = 'index.html';
 
-const BIKESHED_URL = 'http://api.csswg.org/bikeshed/';
+const BIKESHED_URL = 'https://api.csswg.org/bikeshed/';
 
 function checkErrors() {
   let stream = request.post({


### PR DESCRIPTION
- Changed Bikeshed API URL from HTTP to HTTPS for better security in build.js
- Replaced outdated Travis CI badge with GitHub Actions badge in README.md